### PR TITLE
StatutToBrushConverter: avoid throwing in ConvertBack (return Binding.DoNothing)

### DIFF
--- a/Ploco/Converters/StatutToBrushConverter.cs
+++ b/Ploco/Converters/StatutToBrushConverter.cs
@@ -26,7 +26,7 @@ namespace Ploco.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent runtime exceptions from `StatutToBrushConverter.ConvertBack` when WPF attempts to call it by providing a safe no-op return value.

### Description
- Replace `throw new NotImplementedException();` with `return Binding.DoNothing;` in `StatutToBrushConverter.ConvertBack` to avoid throwing during data binding.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5f8b6b248331a3d545769180d05a)