### PR TITLE
Refonte UI : tapis de tuiles, drag & drop des locomotives et persistance SQLite

### DIFF
--- a/Ploco/Converters/StatutToBrushConverter.cs
+++ b/Ploco/Converters/StatutToBrushConverter.cs
@@ -10,9 +10,21 @@ namespace Ploco.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is StatutLocomotive statut)
+            if (value is LocomotiveStatus statut)
             {
                 return statut switch
+                {
+                    LocomotiveStatus.Ok => Brushes.Green,
+                    LocomotiveStatus.DefautMineur => Brushes.Gold,
+                    LocomotiveStatus.AControler => Brushes.Orange,
+                    LocomotiveStatus.HS => Brushes.Red,
+                    _ => Brushes.Gray,
+                };
+            }
+
+            if (value is StatutLocomotive legacyStatut)
+            {
+                return legacyStatut switch
                 {
                     StatutLocomotive.Ok => Brushes.Green,
                     StatutLocomotive.DefautMineur => Brushes.Gold,
@@ -26,7 +38,7 @@ namespace Ploco.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Ploco.Models;
+
+namespace Ploco.Data
+{
+    public class PlocoRepository
+    {
+        private readonly string _connectionString;
+
+        public PlocoRepository(string databasePath)
+        {
+            _connectionString = $"Data Source={databasePath}";
+        }
+
+        public void Initialize()
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            var commands = new[]
+            {
+                @"CREATE TABLE IF NOT EXISTS series (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    start_number INTEGER NOT NULL,
+                    end_number INTEGER NOT NULL
+                );",
+                @"CREATE TABLE IF NOT EXISTS locomotives (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    series_id INTEGER NOT NULL,
+                    number INTEGER NOT NULL,
+                    status TEXT NOT NULL,
+                    FOREIGN KEY(series_id) REFERENCES series(id)
+                );",
+                @"CREATE TABLE IF NOT EXISTS tiles (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    x REAL NOT NULL,
+                    y REAL NOT NULL,
+                    config_json TEXT
+                );",
+                @"CREATE TABLE IF NOT EXISTS tracks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tile_id INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    position INTEGER NOT NULL,
+                    FOREIGN KEY(tile_id) REFERENCES tiles(id)
+                );",
+                @"CREATE TABLE IF NOT EXISTS track_locomotives (
+                    track_id INTEGER NOT NULL,
+                    loco_id INTEGER NOT NULL,
+                    position INTEGER NOT NULL,
+                    PRIMARY KEY(track_id, loco_id),
+                    FOREIGN KEY(track_id) REFERENCES tracks(id),
+                    FOREIGN KEY(loco_id) REFERENCES locomotives(id)
+                );",
+                @"CREATE TABLE IF NOT EXISTS history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    details TEXT NOT NULL
+                );"
+            };
+
+            foreach (var sql in commands)
+            {
+                using var command = connection.CreateCommand();
+                command.CommandText = sql;
+                command.ExecuteNonQuery();
+            }
+        }
+
+        public AppState LoadState()
+        {
+            var state = new AppState();
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            var series = new Dictionary<int, RollingStockSeries>();
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT id, name, start_number, end_number FROM series;";
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    var item = new RollingStockSeries
+                    {
+                        Id = reader.GetInt32(0),
+                        Name = reader.GetString(1),
+                        StartNumber = reader.GetInt32(2),
+                        EndNumber = reader.GetInt32(3)
+                    };
+                    series[item.Id] = item;
+                    state.Series.Add(item);
+                }
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT id, series_id, number, status FROM locomotives;";
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    var seriesId = reader.GetInt32(1);
+                    var seriesName = series.TryGetValue(seriesId, out var serie) ? serie.Name : "Serie";
+                    state.Locomotives.Add(new LocomotiveModel
+                    {
+                        Id = reader.GetInt32(0),
+                        SeriesId = seriesId,
+                        SeriesName = seriesName,
+                        Number = reader.GetInt32(2),
+                        Status = Enum.Parse<LocomotiveStatus>(reader.GetString(3))
+                    });
+                }
+            }
+
+            var tiles = new Dictionary<int, TileModel>();
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT id, name, type, x, y, config_json FROM tiles;";
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    var tile = new TileModel
+                    {
+                        Id = reader.GetInt32(0),
+                        Name = reader.GetString(1),
+                        Type = Enum.Parse<TileType>(reader.GetString(2)),
+                        X = reader.GetDouble(3),
+                        Y = reader.GetDouble(4)
+                    };
+
+                    var configJson = reader.IsDBNull(5) ? null : reader.GetString(5);
+                    if (!string.IsNullOrWhiteSpace(configJson))
+                    {
+                        var config = JsonSerializer.Deserialize<TileConfig>(configJson);
+                        if (config != null)
+                        {
+                            tile.LocationPreset = config.LocationPreset;
+                            tile.GarageTrackNumber = config.GarageTrackNumber;
+                        }
+                    }
+
+                    tiles[tile.Id] = tile;
+                    state.Tiles.Add(tile);
+                }
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT id, tile_id, name, position FROM tracks ORDER BY position;";
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    var track = new TrackModel
+                    {
+                        Id = reader.GetInt32(0),
+                        TileId = reader.GetInt32(1),
+                        Name = reader.GetString(2),
+                        Position = reader.GetInt32(3)
+                    };
+                    if (tiles.TryGetValue(track.TileId, out var tile))
+                    {
+                        tile.Tracks.Add(track);
+                    }
+                }
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT track_id, loco_id, position FROM track_locomotives ORDER BY position;";
+                using var reader = command.ExecuteReader();
+                var locosById = state.Locomotives.ToDictionary(l => l.Id);
+                var tracksById = state.Tiles.SelectMany(t => t.Tracks).ToDictionary(t => t.Id);
+
+                while (reader.Read())
+                {
+                    var trackId = reader.GetInt32(0);
+                    var locoId = reader.GetInt32(1);
+                    if (tracksById.TryGetValue(trackId, out var track) && locosById.TryGetValue(locoId, out var loco))
+                    {
+                        track.Locomotives.Add(loco);
+                        loco.AssignedTrackId = trackId;
+                    }
+                }
+            }
+
+            return state;
+        }
+
+        public void SeedDefaultDataIfNeeded()
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT COUNT(*) FROM series;";
+                var count = (long)command.ExecuteScalar()!;
+                if (count > 0)
+                {
+                    return;
+                }
+            }
+
+            using var transaction = connection.BeginTransaction();
+            var seriesId = InsertSeries(connection, "1300", 1301, 1349);
+            InsertSeries(connection, "37000", 37001, 37040);
+
+            using (var insertLoco = connection.CreateCommand())
+            {
+                insertLoco.CommandText = "INSERT INTO locomotives (series_id, number, status) VALUES ($seriesId, $number, $status);";
+                var seriesParam = insertLoco.CreateParameter();
+                seriesParam.ParameterName = "$seriesId";
+                insertLoco.Parameters.Add(seriesParam);
+                var numberParam = insertLoco.CreateParameter();
+                numberParam.ParameterName = "$number";
+                insertLoco.Parameters.Add(numberParam);
+                var statusParam = insertLoco.CreateParameter();
+                statusParam.ParameterName = "$status";
+                insertLoco.Parameters.Add(statusParam);
+
+                for (var number = 1301; number <= 1349; number++)
+                {
+                    seriesParam.Value = seriesId;
+                    numberParam.Value = number;
+                    statusParam.Value = LocomotiveStatus.Ok.ToString();
+                    insertLoco.ExecuteNonQuery();
+                }
+            }
+
+            transaction.Commit();
+        }
+
+        public void SaveState(AppState state)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+
+            ExecuteNonQuery(connection, "DELETE FROM track_locomotives;");
+            ExecuteNonQuery(connection, "DELETE FROM tracks;");
+            ExecuteNonQuery(connection, "DELETE FROM tiles;");
+            ExecuteNonQuery(connection, "DELETE FROM locomotives;");
+            ExecuteNonQuery(connection, "DELETE FROM series;");
+
+            var seriesIdMap = new Dictionary<int, int>();
+            foreach (var series in state.Series)
+            {
+                var newId = InsertSeries(connection, series.Name, series.StartNumber, series.EndNumber);
+                seriesIdMap[series.Id] = newId;
+                series.Id = newId;
+            }
+
+            foreach (var loco in state.Locomotives)
+            {
+                if (seriesIdMap.TryGetValue(loco.SeriesId, out var newSeriesId))
+                {
+                    loco.SeriesId = newSeriesId;
+                }
+                using var command = connection.CreateCommand();
+                command.CommandText = "INSERT INTO locomotives (series_id, number, status) VALUES ($seriesId, $number, $status);";
+                command.Parameters.AddWithValue("$seriesId", loco.SeriesId);
+                command.Parameters.AddWithValue("$number", loco.Number);
+                command.Parameters.AddWithValue("$status", loco.Status.ToString());
+                command.ExecuteNonQuery();
+                loco.Id = (int)connection.LastInsertRowId;
+            }
+
+            foreach (var tile in state.Tiles)
+            {
+                using var command = connection.CreateCommand();
+                command.CommandText = "INSERT INTO tiles (name, type, x, y, config_json) VALUES ($name, $type, $x, $y, $config);";
+                command.Parameters.AddWithValue("$name", tile.Name);
+                command.Parameters.AddWithValue("$type", tile.Type.ToString());
+                command.Parameters.AddWithValue("$x", tile.X);
+                command.Parameters.AddWithValue("$y", tile.Y);
+                var configJson = JsonSerializer.Serialize(new TileConfig
+                {
+                    LocationPreset = tile.LocationPreset,
+                    GarageTrackNumber = tile.GarageTrackNumber
+                });
+                command.Parameters.AddWithValue("$config", configJson);
+                command.ExecuteNonQuery();
+                tile.Id = (int)connection.LastInsertRowId;
+
+                var trackPosition = 0;
+                foreach (var track in tile.Tracks)
+                {
+                    using var trackCommand = connection.CreateCommand();
+                    trackCommand.CommandText = "INSERT INTO tracks (tile_id, name, position) VALUES ($tileId, $name, $position);";
+                    trackCommand.Parameters.AddWithValue("$tileId", tile.Id);
+                    trackCommand.Parameters.AddWithValue("$name", track.Name);
+                    trackCommand.Parameters.AddWithValue("$position", trackPosition++);
+                    trackCommand.ExecuteNonQuery();
+                    track.Id = (int)connection.LastInsertRowId;
+
+                    var locoPosition = 0;
+                    foreach (var loco in track.Locomotives)
+                    {
+                        using var assignCommand = connection.CreateCommand();
+                        assignCommand.CommandText = "INSERT INTO track_locomotives (track_id, loco_id, position) VALUES ($trackId, $locoId, $position);";
+                        assignCommand.Parameters.AddWithValue("$trackId", track.Id);
+                        assignCommand.Parameters.AddWithValue("$locoId", loco.Id);
+                        assignCommand.Parameters.AddWithValue("$position", locoPosition++);
+                        assignCommand.ExecuteNonQuery();
+                    }
+                }
+            }
+
+            transaction.Commit();
+        }
+
+        public void AddHistory(string action, string details)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "INSERT INTO history (timestamp, action, details) VALUES ($timestamp, $action, $details);";
+            command.Parameters.AddWithValue("$timestamp", DateTime.UtcNow.ToString("O"));
+            command.Parameters.AddWithValue("$action", action);
+            command.Parameters.AddWithValue("$details", details);
+            command.ExecuteNonQuery();
+        }
+
+        private static int InsertSeries(SqliteConnection connection, string name, int startNumber, int endNumber)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = "INSERT INTO series (name, start_number, end_number) VALUES ($name, $start, $end);";
+            command.Parameters.AddWithValue("$name", name);
+            command.Parameters.AddWithValue("$start", startNumber);
+            command.Parameters.AddWithValue("$end", endNumber);
+            command.ExecuteNonQuery();
+            return (int)connection.LastInsertRowId;
+        }
+
+        private static void ExecuteNonQuery(SqliteConnection connection, string sql)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            command.ExecuteNonQuery();
+        }
+
+        private class TileConfig
+        {
+            public string? LocationPreset { get; set; }
+            public int? GarageTrackNumber { get; set; }
+        }
+    }
+}

--- a/Ploco/Dialogs/SimpleTextDialog.xaml
+++ b/Ploco/Dialogs/SimpleTextDialog.xaml
@@ -1,0 +1,14 @@
+<Window x:Class="Ploco.Dialogs.SimpleTextDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Saisie" Height="160" Width="360"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="12">
+        <TextBlock x:Name="PromptText" Margin="0,0,0,6" FontWeight="SemiBold"/>
+        <TextBox x:Name="InputText" Margin="0,0,0,12"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Ploco/Dialogs/SimpleTextDialog.xaml.cs
+++ b/Ploco/Dialogs/SimpleTextDialog.xaml.cs
@@ -1,0 +1,34 @@
+using System.Windows;
+
+namespace Ploco.Dialogs
+{
+    public partial class SimpleTextDialog : Window
+    {
+        public string ResponseText => InputText.Text.Trim();
+
+        public SimpleTextDialog(string title, string prompt, string initialValue)
+        {
+            InitializeComponent();
+            Title = title;
+            PromptText.Text = prompt;
+            InputText.Text = initialValue;
+            InputText.SelectAll();
+            InputText.Focus();
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(ResponseText))
+            {
+                MessageBox.Show("Veuillez saisir une valeur.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/StatusDialog.xaml
+++ b/Ploco/Dialogs/StatusDialog.xaml
@@ -1,0 +1,19 @@
+<Window x:Class="Ploco.Dialogs.StatusDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Modifier statut" Height="200" Width="300"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="12">
+        <TextBlock x:Name="LocoLabel" Margin="0,0,0,10" FontWeight="Bold"/>
+        <ComboBox x:Name="StatusCombo" Margin="0,0,0,12">
+            <ComboBoxItem Content="Ok" Tag="Ok"/>
+            <ComboBoxItem Content="Défaut mineur" Tag="DefautMineur"/>
+            <ComboBoxItem Content="À contrôler" Tag="AControler"/>
+            <ComboBoxItem Content="HS" Tag="HS"/>
+        </ComboBox>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Ploco/Dialogs/StatusDialog.xaml.cs
+++ b/Ploco/Dialogs/StatusDialog.xaml.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class StatusDialog : Window
+    {
+        private readonly LocomotiveModel _locomotive;
+
+        public StatusDialog(LocomotiveModel locomotive)
+        {
+            InitializeComponent();
+            _locomotive = locomotive;
+            LocoLabel.Text = locomotive.DisplayName;
+            StatusCombo.SelectedIndex = (int)locomotive.Status;
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            if (StatusCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag &&
+                Enum.TryParse(tag, out LocomotiveStatus status))
+            {
+                _locomotive.Status = status;
+                DialogResult = true;
+                return;
+            }
+
+            MessageBox.Show("Sélectionnez un statut valide.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/TileConfigDialog.xaml
+++ b/Ploco/Dialogs/TileConfigDialog.xaml
@@ -1,0 +1,35 @@
+<Window x:Class="Ploco.Dialogs.TileConfigDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configurer tuile" Height="260" Width="360"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Nom :" VerticalAlignment="Center" Margin="0,0,8,0"/>
+        <TextBox Grid.Row="0" Grid.Column="1" x:Name="TileNameText" Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Lieu :" VerticalAlignment="Center" Margin="0,0,8,0"/>
+        <StackPanel Grid.Row="1" Grid.Column="1" Margin="0,0,0,8">
+            <ComboBox x:Name="LocationPresetCombo" SelectionChanged="LocationPresetCombo_SelectionChanged"/>
+            <TextBox x:Name="CustomLocationText" Margin="0,6,0,0" Visibility="Collapsed"/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Voie n° :" VerticalAlignment="Center" Margin="0,0,8,0"/>
+        <TextBox Grid.Row="2" Grid.Column="1" x:Name="TrackNumberText" Margin="0,0,0,8"/>
+
+        <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/TileConfigDialog.xaml.cs
+++ b/Ploco/Dialogs/TileConfigDialog.xaml.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Windows;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class TileConfigDialog : Window
+    {
+        private readonly TileModel _tile;
+        private readonly List<string> _presets = new()
+        {
+            "Garage A",
+            "Garage B",
+            "Garage C",
+            "Dépôt Nord",
+            "Dépôt Sud",
+            "Personnalisé"
+        };
+
+        public TileConfigDialog(TileModel tile)
+        {
+            InitializeComponent();
+            _tile = tile;
+            TileNameText.Text = tile.Name;
+            LocationPresetCombo.ItemsSource = _presets;
+            LocationPresetCombo.SelectedItem = tile.LocationPreset ?? _presets[0];
+            TrackNumberText.Text = tile.GarageTrackNumber?.ToString() ?? string.Empty;
+
+            if (tile.Type == TileType.ArretLigne)
+            {
+                LocationPresetCombo.IsEnabled = false;
+                TrackNumberText.IsEnabled = false;
+                CustomLocationText.Visibility = Visibility.Collapsed;
+            }
+            else if (!string.IsNullOrWhiteSpace(tile.LocationPreset) && !_presets.Contains(tile.LocationPreset))
+            {
+                LocationPresetCombo.SelectedItem = "Personnalisé";
+                CustomLocationText.Text = tile.LocationPreset;
+                CustomLocationText.Visibility = Visibility.Visible;
+            }
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(TileNameText.Text))
+            {
+                MessageBox.Show("Le nom est obligatoire.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            _tile.Name = TileNameText.Text.Trim();
+
+            if (_tile.Type == TileType.VoieGarage)
+            {
+                var preset = LocationPresetCombo.SelectedItem?.ToString();
+                if (preset == "Personnalisé")
+                {
+                    _tile.LocationPreset = string.IsNullOrWhiteSpace(CustomLocationText.Text)
+                        ? "Personnalisé"
+                        : CustomLocationText.Text.Trim();
+                }
+                else
+                {
+                    _tile.LocationPreset = preset;
+                }
+                if (int.TryParse(TrackNumberText.Text, out var trackNumber))
+                {
+                    _tile.GarageTrackNumber = trackNumber;
+                }
+                else
+                {
+                    _tile.GarageTrackNumber = null;
+                }
+            }
+
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        private void LocationPresetCombo_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (_tile.Type == TileType.ArretLigne)
+            {
+                return;
+            }
+
+            var preset = LocationPresetCombo.SelectedItem?.ToString();
+            CustomLocationText.Visibility = preset == "Personnalisé" ? Visibility.Visible : Visibility.Collapsed;
+        }
+    }
+}

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -2,97 +2,125 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Ploco.Converters"
-        Title="Gestion des Locomotives" Height="700" Width="1100"
+        Title="Ploco - Nouvelle version" Height="800" Width="1200"
         Icon="pack://application:,,,/img/train_logo.ico"
         Loaded="Window_Loaded" Closing="Window_Closing">
     <Window.Resources>
-        <!-- Convertisseur pour transformer le statut en couleur -->
         <local:StatutToBrushConverter x:Key="StatutToBrushConverter"/>
-        <!-- Menu contextuel pour les locomotives -->
-        <ContextMenu x:Key="LocomotivesContextMenu">
-            <MenuItem Header="Swap" Click="MenuItem_Swap_Click"/>
+        <Style x:Key="TileHeaderButton" TargetType="Button">
+            <Setter Property="Margin" Value="4,0,0,0"/>
+            <Setter Property="Padding" Value="4,0"/>
+            <Setter Property="FontSize" Value="11"/>
+        </Style>
+        <ContextMenu x:Key="LocomotiveContextMenu">
             <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
-            <MenuItem Header="Voir historique" Click="MenuItem_VoirHistorique_Click"/>
+            <MenuItem Header="Retirer de la tuile" Click="MenuItem_RemoveFromTile_Click"/>
         </ContextMenu>
     </Window.Resources>
     <DockPanel>
-        <!-- Menu principal -->
-        <Menu DockPanel.Dock="Top">
-            <MenuItem Header="Fichier">
-                <MenuItem Header="Sauvegarder" Click="MenuItem_Sauvegarder_Click"/>
-                <MenuItem Header="Charger" Click="MenuItem_Charger_Click"/>
-            </MenuItem>
-            <MenuItem Header="Gestion">
-                <MenuItem Header="Gérer les Locomotives" Click="MenuItem_GererLocomotives_Click"/>
-                <MenuItem Header="Parc Loco" Click="MenuItem_ParcLoco_Click"/>
-                <MenuItem Header="Historique" Click="MenuItem_Historique_Click"/>
-            </MenuItem>
-            <MenuItem Header="Option">
-                <MenuItem Header="Reset" Click="MenuItem_Reset_Click"/>
-            </MenuItem>
-        </Menu>
-        <!-- Contenu principal -->
+        <ToolBar DockPanel.Dock="Top">
+            <Button Content="Ajouter dépôt" Click="AddDepot_Click"/>
+            <Button Content="Ajouter arrêt en ligne" Click="AddLineStop_Click"/>
+            <Button Content="Ajouter voie de garage" Click="AddGarage_Click"/>
+        </ToolBar>
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="250"/>
+                <ColumnDefinition Width="260"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <!-- Pool Sibelit affichée -->
-            <Border Grid.Column="0" Margin="10" Background="LightBlue" AllowDrop="True"
-                    Drop="Pool_Drop" DragOver="Pool_DragOver">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <ItemsControl x:Name="PoolItemsControl"
-                                  PreviewMouseLeftButtonDown="PoolItemsControl_PreviewMouseLeftButtonDown"
-                                  PreviewMouseMove="PoolItemsControl_PreviewMouseMove">
+            <Border Grid.Column="0" Margin="10" Background="#FFEFF4FF" CornerRadius="6">
+                <DockPanel>
+                    <TextBlock DockPanel.Dock="Top" Text="Locomotives" FontWeight="Bold" Margin="8"/>
+                    <ListBox x:Name="LocomotiveList"
+                             DisplayMemberPath="DisplayName"
+                             PreviewMouseLeftButtonDown="LocomotiveList_PreviewMouseLeftButtonDown"
+                             PreviewMouseMove="LocomotiveList_PreviewMouseMove"/>
+                </DockPanel>
+            </Border>
+            <Border Grid.Column="1" Margin="10" Background="#FFF7F7F7" CornerRadius="6">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="TileCanvas">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <WrapPanel Orientation="Horizontal"/>
+                                <Canvas />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding X}" />
+                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-            <Border Width="42" Height="32" Margin="5"
-                        Background="{Binding Statut, Converter={StaticResource StatutToBrushConverter}}"
-                        ContextMenu="{StaticResource LocomotivesContextMenu}">
-                  <Border.Style>
-                    <Style TargetType="Border">
-                      <Setter Property="Visibility" Value="Visible"/>
-                      <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsOnCanvas}" Value="True">
-                          <Setter Property="Visibility" Value="Collapsed"/>
-                        </DataTrigger>
-                      </Style.Triggers>
-                    </Style>
-                  </Border.Style>
-                  <TextBlock Text="{Binding NumeroSerie}" 
-                             Foreground="LightGray"
-                             VerticalAlignment="Center" HorizontalAlignment="Center"
-                             FontWeight="Bold"/>
-                </Border>
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
-        </ScrollViewer>
-      </Border>
-      
-      <!-- Zone de dépôt (Canvas) et zone d'info -->
-      <Grid Grid.Column="1" Margin="10">
-        <Viewbox Stretch="Uniform">
-          <Canvas x:Name="MonCanvas" Width="704" Height="65" AllowDrop="True"
-                  DragOver="MonCanvas_DragOver" Drop="MonCanvas_Drop">
-            <!-- Image de fond (le tapis) -->
-            <Image Source="pack://application:,,,/img/spoor.png" 
-                   Canvas.Top="64" 
-                   Width="704" Height="84" Stretch="Fill"
-                   HorizontalAlignment="Center" VerticalAlignment="Top"/>
-          </Canvas>
-        </Viewbox>
-        <!-- Zone d'info affichant le nombre total et le nombre HS (HS en rouge) -->
-        <TextBlock x:Name="InfoZone" HorizontalAlignment="Right" VerticalAlignment="Bottom" 
-                   Margin="10" FontSize="14" TextWrapping="Wrap">
-          Sibelit Pool: 0    HS: 0
-        </TextBlock>
-      </Grid>
-    </Grid>
-  </DockPanel>
+                                <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
+                                        CornerRadius="6" Padding="8" Width="340"
+                                        AllowDrop="True"
+                                        Drop="Tile_Drop"
+                                        MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                                        MouseMove="Tile_MouseMove"
+                                        MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                                    <StackPanel>
+                                        <DockPanel>
+                                            <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="14"/>
+                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                                                <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
+                                                        Click="RenameTile_Click" Tag="{Binding}"/>
+                                                <Button Style="{StaticResource TileHeaderButton}" Content="Configurer"
+                                                        Click="ConfigureTile_Click" Tag="{Binding}"/>
+                                                <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
+                                                        Click="DeleteTile_Click" Tag="{Binding}"/>
+                                            </StackPanel>
+                                        </DockPanel>
+                                        <TextBlock Text="{Binding Type}" Foreground="Gray" FontSize="12" Margin="0,2,0,2"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                                            <TextBlock Text="{Binding LocationPreset}" Foreground="SlateGray" FontSize="11"/>
+                                            <TextBlock Text="{Binding GarageTrackNumber, StringFormat= Voie {0}, TargetNullValue='', FallbackValue=''}"
+                                                       Foreground="SlateGray" FontSize="11" Margin="6,0,0,0"/>
+                                        </StackPanel>
+                                        <ItemsControl ItemsSource="{Binding Tracks}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
+                                                        <StackPanel>
+                                                            <DockPanel>
+                                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                                                <Button DockPanel.Dock="Right" Style="{StaticResource TileHeaderButton}"
+                                                                        Content="Retirer voie" Click="RemoveTrack_Click"
+                                                                        Tag="{Binding}"/>
+                                                            </DockPanel>
+                                                            <ListBox ItemsSource="{Binding Locomotives}"
+                                                                     DisplayMemberPath="DisplayName"
+                                                                     AllowDrop="True"
+                                                                     PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                                     PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                                     Drop="TrackLocomotives_Drop">
+                                                                <ListBox.ItemTemplate>
+                                                                    <DataTemplate>
+                                                                        <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                                Padding="4" Margin="2" CornerRadius="4"
+                                                                                ContextMenu="{StaticResource LocomotiveContextMenu}">
+                                                                            <TextBlock Text="{Binding DisplayName}" Foreground="White" FontWeight="Bold"/>
+                                                                        </Border>
+                                                                    </DataTemplate>
+                                                                </ListBox.ItemTemplate>
+                                                            </ListBox>
+                                                        </StackPanel>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                        <Button Content="Ajouter voie" Margin="0,4,0,0" Click="AddTrack_Click" Tag="{Binding}"/>
+                                        <Border Background="#FFF1F5FF" Padding="4" Margin="0,6,0,0" CornerRadius="4">
+                                            <TextBlock Text="Faites glisser les locomotives depuis la liste vers une voie." FontSize="11"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Border>
+        </Grid>
+    </DockPanel>
 </Window>

--- a/Ploco/Models/AppState.cs
+++ b/Ploco/Models/AppState.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Ploco.Models
+{
+    public class AppState
+    {
+        public List<RollingStockSeries> Series { get; set; } = new();
+        public List<LocomotiveModel> Locomotives { get; set; } = new();
+        public List<TileModel> Tiles { get; set; } = new();
+    }
+}

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -1,0 +1,167 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Ploco.Models
+{
+    public enum LocomotiveStatus
+    {
+        Ok,
+        DefautMineur,
+        AControler,
+        HS
+    }
+
+    public enum TileType
+    {
+        Depot,
+        ArretLigne,
+        VoieGarage
+    }
+
+    public class RollingStockSeries
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int StartNumber { get; set; }
+        public int EndNumber { get; set; }
+    }
+
+    public class LocomotiveModel : INotifyPropertyChanged
+    {
+        private LocomotiveStatus _status;
+        private int? _assignedTrackId;
+
+        public int Id { get; set; }
+        public int SeriesId { get; set; }
+        public string SeriesName { get; set; } = string.Empty;
+        public int Number { get; set; }
+
+        public LocomotiveStatus Status
+        {
+            get => _status;
+            set
+            {
+                if (_status != value)
+                {
+                    _status = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public int? AssignedTrackId
+        {
+            get => _assignedTrackId;
+            set
+            {
+                if (_assignedTrackId != value)
+                {
+                    _assignedTrackId = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string DisplayName => $"{SeriesName}-{Number}";
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    public class TrackModel : INotifyPropertyChanged
+    {
+        private string _name = string.Empty;
+
+        public int Id { get; set; }
+        public int TileId { get; set; }
+        public int Position { get; set; }
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (_name != value)
+                {
+                    _name = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public ObservableCollection<LocomotiveModel> Locomotives { get; } = new ObservableCollection<LocomotiveModel>();
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    public class TileModel : INotifyPropertyChanged
+    {
+        private string _name = string.Empty;
+        private double _x;
+        private double _y;
+
+        public int Id { get; set; }
+        public TileType Type { get; set; }
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (_name != value)
+                {
+                    _name = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string? LocationPreset { get; set; }
+        public int? GarageTrackNumber { get; set; }
+
+        public double X
+        {
+            get => _x;
+            set
+            {
+                if (_x != value)
+                {
+                    _x = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public double Y
+        {
+            get => _y;
+            set
+            {
+                if (_y != value)
+                {
+                    _y = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public ObservableCollection<TrackModel> Tracks { get; } = new ObservableCollection<TrackModel>();
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Ploco/Ploco.csproj
+++ b/Ploco/Ploco.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Remplacer l'ancienne interface par une version organisée autour d'un tapis (canvas) de « tuiles » pour mieux gérer lieux, voies et position libre des tuiles. 
- Offrir un mécanisme de persistance robuste avec historique pour garantir la restauration complète de l'état à chaque redémarrage.
- Permettre le glisser‑déposer des locomotives entre pool et tuiles/voies et maintenir l'unicité et l'ordre des locomotives.

### Description
- Nouvelle couche de modèles métier avec `LocomotiveModel`, `TrackModel`, `TileModel`, `RollingStockSeries` et énumérations dans `Ploco/Models/DomainModels.cs` et état applicatif `Ploco/Models/AppState.cs`.
- Ajout d'un repository SQLite `Ploco/Data/PlocoRepository.cs` qui crée le schéma (`series`, `locomotives`, `tiles`, `tracks`, `track_locomotives`, `history`), charge/enregistre l'`AppState`, gère le seed initial et journalise les actions via `AddHistory`.
- Refonte complète de la fenêtre principale : `Ploco/MainWindow.xaml` et son code‑behind `Ploco/MainWindow.xaml.cs` fournissent la liste des locomotives à gauche, un `Canvas` d'items (tuiles) à droite, création/renommage/configuration/suppression de tuiles, ajout/suppression de voies, drag & drop des locomotives entre voies (avec insertion à l'index calculé) et déplacement libre des tuiles sur le tapis.
- Boîtes de dialogue ajoutées pour saisie et configuration : `Ploco/Dialogs/SimpleTextDialog`, `Ploco/Dialogs/StatusDialog` et `Ploco/Dialogs/TileConfigDialog` pour renommer, modifier le statut et configurer une tuile (avec preset + option personnalisée).
- Conversion de statut adaptée : `Ploco/Converters/StatutToBrushConverter.cs` étend la compatibilité aux nouveaux types `LocomotiveStatus` tout en supportant l'ancien `StatutLocomotive`, et `ConvertBack` renvoie désormais `Binding.DoNothing` pour éviter les exceptions pendant le binding.
- Projet mis à jour (`Ploco/Ploco.csproj`) pour ajouter la dépendance `Microsoft.Data.Sqlite`.

### Testing
- Aucune suite de tests automatisés n'a été exécutée pour ce patch.
- Les changements ont été implémentés pour lancer la création du schéma via `PlocoRepository.Initialize()` et pour peupler des données par `SeedDefaultDataIfNeeded()` lors du chargement de la fenêtre, mais cela n'a pas été validé via un test automatisé ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5f8b6b248331a3d545769180d05a)