### PR TITLE
Fix sqlite last insert row id retrieval

### DIFF
--- a/Ploco/Converters/StatutToBrushConverter.cs
+++ b/Ploco/Converters/StatutToBrushConverter.cs
@@ -15,8 +15,7 @@ namespace Ploco.Converters
                 return statut switch
                 {
                     LocomotiveStatus.Ok => Brushes.Green,
-                    LocomotiveStatus.DefautMineur => Brushes.Gold,
-                    LocomotiveStatus.AControler => Brushes.Orange,
+                    LocomotiveStatus.ManqueTraction => Brushes.Orange,
                     LocomotiveStatus.HS => Brushes.Red,
                     _ => Brushes.Gray,
                 };

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -343,7 +343,7 @@ namespace Ploco.Data
                         IssueReason = track.IssueReason,
                         IsLocomotiveHs = track.IsLocomotiveHs
                     });
-                    trackCommand.Parameters.AddWithValue("$config", track.Kind == TrackKind.Line ? trackConfigJson : null);
+                    trackCommand.Parameters.AddWithValue("$config", track.Kind == TrackKind.Line ? trackConfigJson : DBNull.Value);
                     trackCommand.ExecuteNonQuery();
                     track.Id = GetLastInsertRowId(connection);
 

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -196,6 +196,8 @@ namespace Ploco.Data
                             track.IsLocomotiveHs = config.IsLocomotiveHs;
                             track.LeftLabel = config.LeftLabel;
                             track.RightLabel = config.RightLabel;
+                            track.IsLeftBlocked = config.IsLeftBlocked;
+                            track.IsRightBlocked = config.IsRightBlocked;
                         }
                     }
                     if (tiles.TryGetValue(track.TileId, out var tile))
@@ -348,9 +350,15 @@ namespace Ploco.Data
                         IssueReason = track.IssueReason,
                         IsLocomotiveHs = track.IsLocomotiveHs,
                         LeftLabel = track.LeftLabel,
-                        RightLabel = track.RightLabel
+                        RightLabel = track.RightLabel,
+                        IsLeftBlocked = track.IsLeftBlocked,
+                        IsRightBlocked = track.IsRightBlocked
                     });
-                    object configValue = track.Kind == TrackKind.Line || !string.IsNullOrWhiteSpace(track.LeftLabel) || !string.IsNullOrWhiteSpace(track.RightLabel)
+                    object configValue = track.Kind == TrackKind.Line
+                        || !string.IsNullOrWhiteSpace(track.LeftLabel)
+                        || !string.IsNullOrWhiteSpace(track.RightLabel)
+                        || track.IsLeftBlocked
+                        || track.IsRightBlocked
                         ? trackConfigJson
                         : DBNull.Value;
                     trackCommand.Parameters.AddWithValue("$config", configValue);
@@ -542,6 +550,8 @@ namespace Ploco.Data
             public bool IsLocomotiveHs { get; set; }
             public string? LeftLabel { get; set; }
             public string? RightLabel { get; set; }
+            public bool IsLeftBlocked { get; set; }
+            public bool IsRightBlocked { get; set; }
         }
     }
 }

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -269,7 +269,7 @@ namespace Ploco.Data
                 command.Parameters.AddWithValue("$number", loco.Number);
                 command.Parameters.AddWithValue("$status", loco.Status.ToString());
                 command.ExecuteNonQuery();
-                loco.Id = (int)connection.LastInsertRowId;
+                loco.Id = GetLastInsertRowId(connection);
             }
 
             foreach (var tile in state.Tiles)
@@ -287,7 +287,7 @@ namespace Ploco.Data
                 });
                 command.Parameters.AddWithValue("$config", configJson);
                 command.ExecuteNonQuery();
-                tile.Id = (int)connection.LastInsertRowId;
+                tile.Id = GetLastInsertRowId(connection);
 
                 var trackPosition = 0;
                 foreach (var track in tile.Tracks)
@@ -298,7 +298,7 @@ namespace Ploco.Data
                     trackCommand.Parameters.AddWithValue("$name", track.Name);
                     trackCommand.Parameters.AddWithValue("$position", trackPosition++);
                     trackCommand.ExecuteNonQuery();
-                    track.Id = (int)connection.LastInsertRowId;
+                    track.Id = GetLastInsertRowId(connection);
 
                     var locoPosition = 0;
                     foreach (var loco in track.Locomotives)
@@ -336,7 +336,7 @@ namespace Ploco.Data
             command.Parameters.AddWithValue("$start", startNumber);
             command.Parameters.AddWithValue("$end", endNumber);
             command.ExecuteNonQuery();
-            return (int)connection.LastInsertRowId;
+            return GetLastInsertRowId(connection);
         }
 
         private static void ExecuteNonQuery(SqliteConnection connection, string sql)
@@ -344,6 +344,13 @@ namespace Ploco.Data
             using var command = connection.CreateCommand();
             command.CommandText = sql;
             command.ExecuteNonQuery();
+        }
+
+        private static int GetLastInsertRowId(SqliteConnection connection)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT last_insert_rowid();";
+            return Convert.ToInt32(command.ExecuteScalar());
         }
 
         private class TileConfig

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -191,6 +191,7 @@ namespace Ploco.Data
                         if (config != null)
                         {
                             track.IsOnTrain = config.IsOnTrain;
+                            track.TrainNumber = config.TrainNumber;
                             track.StopTime = config.StopTime;
                             track.IssueReason = config.IssueReason;
                             track.IsLocomotiveHs = config.IsLocomotiveHs;
@@ -346,6 +347,7 @@ namespace Ploco.Data
                     var trackConfigJson = JsonSerializer.Serialize(new TrackConfig
                     {
                         IsOnTrain = track.IsOnTrain,
+                        TrainNumber = track.TrainNumber,
                         StopTime = track.StopTime,
                         IssueReason = track.IssueReason,
                         IsLocomotiveHs = track.IsLocomotiveHs,
@@ -355,6 +357,7 @@ namespace Ploco.Data
                         IsRightBlocked = track.IsRightBlocked
                     });
                     object configValue = track.Kind == TrackKind.Line
+                        || !string.IsNullOrWhiteSpace(track.TrainNumber)
                         || !string.IsNullOrWhiteSpace(track.LeftLabel)
                         || !string.IsNullOrWhiteSpace(track.RightLabel)
                         || track.IsLeftBlocked
@@ -545,6 +548,7 @@ namespace Ploco.Data
         private class TrackConfig
         {
             public bool IsOnTrain { get; set; }
+            public string? TrainNumber { get; set; }
             public string? StopTime { get; set; }
             public string? IssueReason { get; set; }
             public bool IsLocomotiveHs { get; set; }

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -241,7 +241,7 @@ namespace Ploco.Data
                     {
                         track.Locomotives.Add(loco);
                         loco.AssignedTrackId = trackId;
-                        var offset = reader.IsDBNull(3) ? null : reader.GetDouble(3);
+                        var offset = reader.IsDBNull(3) ? (double?)null : reader.GetDouble(3);
                         loco.AssignedTrackOffsetX = track.Kind == TrackKind.Line || track.Kind == TrackKind.Zone || track.Kind == TrackKind.Output
                             ? offset
                             : null;

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -194,6 +194,8 @@ namespace Ploco.Data
                             track.StopTime = config.StopTime;
                             track.IssueReason = config.IssueReason;
                             track.IsLocomotiveHs = config.IsLocomotiveHs;
+                            track.LeftLabel = config.LeftLabel;
+                            track.RightLabel = config.RightLabel;
                         }
                     }
                     if (tiles.TryGetValue(track.TileId, out var tile))
@@ -344,9 +346,14 @@ namespace Ploco.Data
                         IsOnTrain = track.IsOnTrain,
                         StopTime = track.StopTime,
                         IssueReason = track.IssueReason,
-                        IsLocomotiveHs = track.IsLocomotiveHs
+                        IsLocomotiveHs = track.IsLocomotiveHs,
+                        LeftLabel = track.LeftLabel,
+                        RightLabel = track.RightLabel
                     });
-                    trackCommand.Parameters.AddWithValue("$config", track.Kind == TrackKind.Line ? trackConfigJson : DBNull.Value);
+                    var configValue = track.Kind == TrackKind.Line || !string.IsNullOrWhiteSpace(track.LeftLabel) || !string.IsNullOrWhiteSpace(track.RightLabel)
+                        ? trackConfigJson
+                        : DBNull.Value;
+                    trackCommand.Parameters.AddWithValue("$config", configValue);
                     trackCommand.ExecuteNonQuery();
                     track.Id = GetLastInsertRowId(connection);
 
@@ -533,6 +540,8 @@ namespace Ploco.Data
             public string? StopTime { get; set; }
             public string? IssueReason { get; set; }
             public bool IsLocomotiveHs { get; set; }
+            public string? LeftLabel { get; set; }
+            public string? RightLabel { get; set; }
         }
     }
 }

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -350,7 +350,7 @@ namespace Ploco.Data
                         LeftLabel = track.LeftLabel,
                         RightLabel = track.RightLabel
                     });
-                    var configValue = track.Kind == TrackKind.Line || !string.IsNullOrWhiteSpace(track.LeftLabel) || !string.IsNullOrWhiteSpace(track.RightLabel)
+                    object configValue = track.Kind == TrackKind.Line || !string.IsNullOrWhiteSpace(track.LeftLabel) || !string.IsNullOrWhiteSpace(track.RightLabel)
                         ? trackConfigJson
                         : DBNull.Value;
                     trackCommand.Parameters.AddWithValue("$config", configValue);

--- a/Ploco/Dialogs/DatabaseManagementWindow.xaml
+++ b/Ploco/Dialogs/DatabaseManagementWindow.xaml
@@ -1,0 +1,56 @@
+<Window x:Class="Ploco.Dialogs.DatabaseManagementWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Gestion base de données" Height="600" Width="900"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Visualisation en lecture seule des données et nettoyage des éléments non essentiels."
+                   FontWeight="SemiBold" Margin="0,0,0,8"/>
+
+        <TabControl Grid.Row="1">
+            <TabItem Header="Résumé">
+                <DataGrid x:Name="SummaryGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserAddRows="False" CanUserDeleteRows="False" HeadersVisibility="Column">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Table" Binding="{Binding Name}" Width="*"/>
+                        <DataGridTextColumn Header="Enregistrements" Binding="{Binding Count}" Width="Auto"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+            <TabItem Header="Historique">
+                <DataGrid x:Name="HistoryGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserAddRows="False" CanUserDeleteRows="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Date" Binding="{Binding Timestamp}" Width="180"/>
+                        <DataGridTextColumn Header="Action" Binding="{Binding Action}" Width="160"/>
+                        <DataGridTextColumn Header="Détails" Binding="{Binding Details}" Width="*"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+            <TabItem Header="États locomotives">
+                <DataGrid x:Name="LocomotiveGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserAddRows="False" CanUserDeleteRows="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Numéro" Binding="{Binding Number}" Width="100"/>
+                        <DataGridTextColumn Header="Pool" Binding="{Binding Pool}" Width="120"/>
+                        <DataGridTextColumn Header="Statut" Binding="{Binding Status}" Width="120"/>
+                        <DataGridTextColumn Header="Traction %" Binding="{Binding TractionPercent}" Width="120"/>
+                        <DataGridTextColumn Header="Raison HS" Binding="{Binding HsReason}" Width="*"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+        </TabControl>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Vider l'historique" Width="160" Margin="0,0,8,0" Click="ClearHistory_Click"/>
+            <Button Content="Vider les données temporaires" Width="200" Margin="0,0,8,0" Click="ClearTempData_Click"/>
+            <Button Content="Réinitialiser les données d'état" Width="220" Click="ResetOperationalState_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/DatabaseManagementWindow.xaml.cs
+++ b/Ploco/Dialogs/DatabaseManagementWindow.xaml.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using Ploco.Data;
+using Ploco.Helpers;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class DatabaseManagementWindow : Window, IRefreshableWindow
+    {
+        private readonly PlocoRepository _repository;
+        private readonly IEnumerable<LocomotiveModel> _locomotives;
+        private readonly IEnumerable<TileModel> _tiles;
+        private readonly ObservableCollection<TableSummary> _summaries = new();
+        private readonly ObservableCollection<HistoryEntry> _history = new();
+        private readonly ObservableCollection<LocomotiveStateRow> _locomotiveStates = new();
+
+        public DatabaseManagementWindow(PlocoRepository repository, IEnumerable<LocomotiveModel> locomotives, IEnumerable<TileModel> tiles)
+        {
+            InitializeComponent();
+            _repository = repository;
+            _locomotives = locomotives;
+            _tiles = tiles;
+            SummaryGrid.ItemsSource = _summaries;
+            HistoryGrid.ItemsSource = _history;
+            LocomotiveGrid.ItemsSource = _locomotiveStates;
+            RefreshData();
+        }
+
+        public void RefreshData()
+        {
+            LoadSummary();
+            LoadHistory();
+            LoadLocomotiveStates();
+        }
+
+        private void LoadSummary()
+        {
+            _summaries.Clear();
+            var counts = _repository.GetTableCounts();
+            var trackCounts = _repository.GetTrackKindCounts();
+
+            AddSummary("Séries", counts.GetValueOrDefault("series"));
+            AddSummary("Locomotives", counts.GetValueOrDefault("locomotives"));
+            AddSummary("Lieux (tuiles)", counts.GetValueOrDefault("tiles"));
+            AddSummary("Voies", counts.GetValueOrDefault("tracks"));
+            AddSummary("Assignations", counts.GetValueOrDefault("track_locomotives"));
+            AddSummary("Historique", counts.GetValueOrDefault("history"));
+            AddSummary("Lieux enregistrés", counts.GetValueOrDefault("places"));
+
+            if (trackCounts.Any())
+            {
+                foreach (var entry in trackCounts.OrderBy(k => k.Key))
+                {
+                    AddSummary($"Voies ({entry.Key})", entry.Value);
+                }
+            }
+        }
+
+        private void AddSummary(string name, int count)
+        {
+            _summaries.Add(new TableSummary
+            {
+                Name = name,
+                Count = count
+            });
+        }
+
+        private void LoadHistory()
+        {
+            _history.Clear();
+            foreach (var entry in _repository.LoadHistory())
+            {
+                _history.Add(entry);
+            }
+        }
+
+        private void LoadLocomotiveStates()
+        {
+            _locomotiveStates.Clear();
+            foreach (var loco in _locomotives.OrderBy(l => l.Number))
+            {
+                _locomotiveStates.Add(new LocomotiveStateRow
+                {
+                    Number = loco.Number,
+                    Pool = loco.Pool,
+                    Status = loco.Status.ToString(),
+                    TractionPercent = loco.TractionPercent?.ToString() ?? string.Empty,
+                    HsReason = loco.HsReason ?? string.Empty
+                });
+            }
+        }
+
+        private void ClearHistory_Click(object sender, RoutedEventArgs e)
+        {
+            var result = MessageBox.Show("Voulez-vous vraiment vider l'historique ?",
+                "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            try
+            {
+                _repository.ClearHistory();
+                MessageBox.Show("Nettoyage terminé : historique vidé.", "Information",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Erreur lors du nettoyage de l'historique : {ex.Message}", "Erreur",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            RefreshData();
+        }
+
+        private void ClearTempData_Click(object sender, RoutedEventArgs e)
+        {
+            var result = MessageBox.Show("Voulez-vous vraiment supprimer les données temporaires ?",
+                "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            var deleted = new List<string>();
+            try
+            {
+                var basePath = AppDomain.CurrentDomain.BaseDirectory;
+                deleted.AddRange(DeleteIfExists(Path.Combine(basePath, "SwapLog.txt")));
+                deleted.AddRange(DeleteIfExists(Path.Combine(basePath, "StatutModificationLog.txt")));
+
+                if (!deleted.Any())
+                {
+                    MessageBox.Show("Aucune donnée temporaire à supprimer.", "Information",
+                        MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+                else
+                {
+                    MessageBox.Show("Nettoyage terminé : données temporaires supprimées.", "Information",
+                        MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Erreur lors du nettoyage des données temporaires : {ex.Message}", "Erreur",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            RefreshData();
+        }
+
+        private static IEnumerable<string> DeleteIfExists(string path)
+        {
+            if (!File.Exists(path))
+            {
+                return Array.Empty<string>();
+            }
+
+            File.Delete(path);
+            return new[] { path };
+        }
+
+        private void ResetOperationalState_Click(object sender, RoutedEventArgs e)
+        {
+            var result = MessageBox.Show("Voulez-vous vraiment réinitialiser les données d'état (traction, raisons HS, incidents en ligne) ?",
+                "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            try
+            {
+                _repository.ResetOperationalState();
+                foreach (var loco in _locomotives)
+                {
+                    loco.TractionPercent = null;
+                    loco.HsReason = null;
+                }
+                foreach (var track in _tiles.SelectMany(tile => tile.Tracks))
+                {
+                    if (track.Kind != TrackKind.Line)
+                    {
+                        continue;
+                    }
+
+                    track.IsOnTrain = false;
+                    track.TrainNumber = null;
+                    track.StopTime = null;
+                    track.IssueReason = null;
+                    track.IsLocomotiveHs = false;
+                }
+                MessageBox.Show("Nettoyage terminé : données d'état réinitialisées.", "Information",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Erreur lors de la réinitialisation : {ex.Message}", "Erreur",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            RefreshData();
+        }
+
+        private sealed class TableSummary
+        {
+            public string Name { get; set; } = string.Empty;
+            public int Count { get; set; }
+        }
+
+        private sealed class LocomotiveStateRow
+        {
+            public int Number { get; set; }
+            public string Pool { get; set; } = string.Empty;
+            public string Status { get; set; } = string.Empty;
+            public string TractionPercent { get; set; } = string.Empty;
+            public string HsReason { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Ploco/Dialogs/LinePlaceDialog.xaml
+++ b/Ploco/Dialogs/LinePlaceDialog.xaml
@@ -8,6 +8,9 @@
             <TextBlock Text="Nom du lieu" FontWeight="SemiBold"/>
             <TextBox x:Name="PlaceNameText" Margin="0,6,0,12"/>
 
+            <TextBlock Text="Nom de la voie" FontWeight="SemiBold"/>
+            <TextBox x:Name="TrackNameText" Margin="0,6,0,12"/>
+
             <TextBlock Text="Locomotives à ajouter (séparées par espace ou virgule)" FontWeight="SemiBold"/>
             <TextBox x:Name="LocomotiveNumbersText" Margin="0,6,0,12"/>
 

--- a/Ploco/Dialogs/LinePlaceDialog.xaml
+++ b/Ploco/Dialogs/LinePlaceDialog.xaml
@@ -1,0 +1,42 @@
+<Window x:Class="Ploco.Dialogs.LinePlaceDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configurer un lieu en ligne" Height="520" Width="460"
+        WindowStartupLocation="CenterOwner">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="12">
+            <TextBlock Text="Nom du lieu" FontWeight="SemiBold"/>
+            <TextBox x:Name="PlaceNameText" Margin="0,6,0,12"/>
+
+            <TextBlock Text="Locomotives à ajouter (séparées par espace ou virgule)" FontWeight="SemiBold"/>
+            <TextBox x:Name="LocomotiveNumbersText" Margin="0,6,0,12"/>
+
+            <TextBlock Text="Raison de l'incident" FontWeight="SemiBold"/>
+            <TextBox x:Name="IssueReasonText" Margin="0,6,0,12"/>
+
+            <CheckBox x:Name="OnTrainCheck" Content="Locomotive sur un train ?" Margin="0,0,0,6"
+                      Checked="OnTrainCheck_Checked" Unchecked="OnTrainCheck_Checked"/>
+
+            <StackPanel x:Name="TrainDetailsPanel" Visibility="Collapsed">
+                <TextBlock Text="Numéro de train" FontWeight="SemiBold"/>
+                <TextBox x:Name="TrainNumberText" Margin="0,6,0,12"/>
+
+                <TextBlock Text="Heure d'arrêt" FontWeight="SemiBold"/>
+                <TextBox x:Name="StopTimeText" Margin="0,6,0,12"/>
+            </StackPanel>
+
+            <CheckBox x:Name="IsHsCheck" Content="Locomotive HS ?" Margin="0,0,0,6"
+                      Checked="IsHsCheck_Checked" Unchecked="IsHsCheck_Checked"/>
+
+            <StackPanel x:Name="HsLocomotivesPanel" Visibility="Collapsed">
+                <TextBlock Text="Locomotives HS (séparées par espace ou virgule)" FontWeight="SemiBold"/>
+                <TextBox x:Name="HsLocomotivesText" Margin="0,6,0,12"/>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+                <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Window>

--- a/Ploco/Dialogs/LinePlaceDialog.xaml.cs
+++ b/Ploco/Dialogs/LinePlaceDialog.xaml.cs
@@ -14,6 +14,7 @@ namespace Ploco.Dialogs
         }
 
         public string PlaceName => PlaceNameText.Text.Trim();
+        public string TrackName => TrackNameText.Text.Trim();
         public string LocomotiveNumbers => LocomotiveNumbersText.Text.Trim();
         public string IssueReason => IssueReasonText.Text.Trim();
         public bool IsOnTrain => OnTrainCheck.IsChecked == true;
@@ -37,6 +38,12 @@ namespace Ploco.Dialogs
             if (string.IsNullOrWhiteSpace(PlaceName))
             {
                 MessageBox.Show("Veuillez saisir un nom de lieu.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(TrackName))
+            {
+                MessageBox.Show("Veuillez saisir un nom de voie.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 

--- a/Ploco/Dialogs/LinePlaceDialog.xaml.cs
+++ b/Ploco/Dialogs/LinePlaceDialog.xaml.cs
@@ -1,0 +1,69 @@
+using System.Windows;
+
+namespace Ploco.Dialogs
+{
+    public partial class LinePlaceDialog : Window
+    {
+        public LinePlaceDialog(string? placeName = null)
+        {
+            InitializeComponent();
+            if (!string.IsNullOrWhiteSpace(placeName))
+            {
+                PlaceNameText.Text = placeName;
+            }
+        }
+
+        public string PlaceName => PlaceNameText.Text.Trim();
+        public string LocomotiveNumbers => LocomotiveNumbersText.Text.Trim();
+        public string IssueReason => IssueReasonText.Text.Trim();
+        public bool IsOnTrain => OnTrainCheck.IsChecked == true;
+        public string TrainNumber => TrainNumberText.Text.Trim();
+        public string StopTime => StopTimeText.Text.Trim();
+        public bool IsLocomotiveHs => IsHsCheck.IsChecked == true;
+        public string HsLocomotiveNumbers => HsLocomotivesText.Text.Trim();
+
+        private void OnTrainCheck_Checked(object sender, RoutedEventArgs e)
+        {
+            TrainDetailsPanel.Visibility = OnTrainCheck.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void IsHsCheck_Checked(object sender, RoutedEventArgs e)
+        {
+            HsLocomotivesPanel.Visibility = IsHsCheck.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(PlaceName))
+            {
+                MessageBox.Show("Veuillez saisir un nom de lieu.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(IssueReason))
+            {
+                MessageBox.Show("Veuillez saisir une raison d'incident.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (IsOnTrain && string.IsNullOrWhiteSpace(TrainNumber))
+            {
+                MessageBox.Show("Veuillez saisir le numéro du train.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (IsLocomotiveHs && string.IsNullOrWhiteSpace(HsLocomotiveNumbers))
+            {
+                MessageBox.Show("Veuillez saisir les locomotives HS.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/LineTrackDialog.xaml
+++ b/Ploco/Dialogs/LineTrackDialog.xaml
@@ -11,14 +11,17 @@
                   Checked="OnTrainCheck_Checked" Unchecked="OnTrainCheck_Checked"/>
 
         <StackPanel x:Name="TrainDetailsPanel" Visibility="Collapsed">
+            <TextBlock Text="Numéro de train" FontWeight="SemiBold"/>
+            <TextBox x:Name="TrainNumberText" Margin="0,6,0,12"/>
+
             <TextBlock Text="Heure d'arrêt" FontWeight="SemiBold"/>
             <TextBox x:Name="StopTimeText" Margin="0,6,0,12"/>
-
-            <TextBlock Text="Raison du problème" FontWeight="SemiBold"/>
-            <TextBox x:Name="IssueReasonText" Margin="0,6,0,12"/>
-
-            <CheckBox x:Name="IsHsCheck" Content="Locomotive HS ?" Margin="0,0,0,12"/>
         </StackPanel>
+
+        <TextBlock Text="Raison du problème" FontWeight="SemiBold"/>
+        <TextBox x:Name="IssueReasonText" Margin="0,6,0,12"/>
+
+        <CheckBox x:Name="IsHsCheck" Content="Locomotive HS ?" Margin="0,0,0,12"/>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>

--- a/Ploco/Dialogs/LineTrackDialog.xaml
+++ b/Ploco/Dialogs/LineTrackDialog.xaml
@@ -1,0 +1,28 @@
+<Window x:Class="Ploco.Dialogs.LineTrackDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configurer une voie" Height="360" Width="420"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="12">
+        <TextBlock Text="Nom de la voie" FontWeight="SemiBold"/>
+        <TextBox x:Name="TrackNameText" Margin="0,6,0,12"/>
+
+        <CheckBox x:Name="OnTrainCheck" Content="Locomotive sur un train ?" Margin="0,0,0,6"
+                  Checked="OnTrainCheck_Checked" Unchecked="OnTrainCheck_Checked"/>
+
+        <StackPanel x:Name="TrainDetailsPanel" Visibility="Collapsed">
+            <TextBlock Text="Heure d'arrêt" FontWeight="SemiBold"/>
+            <TextBox x:Name="StopTimeText" Margin="0,6,0,12"/>
+
+            <TextBlock Text="Raison du problème" FontWeight="SemiBold"/>
+            <TextBox x:Name="IssueReasonText" Margin="0,6,0,12"/>
+
+            <CheckBox x:Name="IsHsCheck" Content="Locomotive HS ?" Margin="0,0,0,12"/>
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Ploco/Dialogs/LineTrackDialog.xaml.cs
+++ b/Ploco/Dialogs/LineTrackDialog.xaml.cs
@@ -12,11 +12,13 @@ namespace Ploco.Dialogs
 
         public TrackModel BuildTrack()
         {
+            var isOnTrain = OnTrainCheck.IsChecked == true;
             return new TrackModel
             {
                 Name = TrackNameText.Text.Trim(),
-                IsOnTrain = OnTrainCheck.IsChecked == true,
-                StopTime = StopTimeText.Text.Trim(),
+                IsOnTrain = isOnTrain,
+                TrainNumber = isOnTrain ? TrainNumberText.Text.Trim() : null,
+                StopTime = isOnTrain ? StopTimeText.Text.Trim() : null,
                 IssueReason = IssueReasonText.Text.Trim(),
                 IsLocomotiveHs = IsHsCheck.IsChecked == true
             };
@@ -32,6 +34,18 @@ namespace Ploco.Dialogs
             if (string.IsNullOrWhiteSpace(TrackNameText.Text))
             {
                 MessageBox.Show("Veuillez saisir un nom de voie.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(IssueReasonText.Text))
+            {
+                MessageBox.Show("Veuillez saisir une raison.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (OnTrainCheck.IsChecked == true && string.IsNullOrWhiteSpace(TrainNumberText.Text))
+            {
+                MessageBox.Show("Veuillez saisir un numéro de train.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 

--- a/Ploco/Dialogs/LineTrackDialog.xaml.cs
+++ b/Ploco/Dialogs/LineTrackDialog.xaml.cs
@@ -1,0 +1,46 @@
+using System.Windows;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class LineTrackDialog : Window
+    {
+        public LineTrackDialog()
+        {
+            InitializeComponent();
+        }
+
+        public TrackModel BuildTrack()
+        {
+            return new TrackModel
+            {
+                Name = TrackNameText.Text.Trim(),
+                IsOnTrain = OnTrainCheck.IsChecked == true,
+                StopTime = StopTimeText.Text.Trim(),
+                IssueReason = IssueReasonText.Text.Trim(),
+                IsLocomotiveHs = IsHsCheck.IsChecked == true
+            };
+        }
+
+        private void OnTrainCheck_Checked(object sender, RoutedEventArgs e)
+        {
+            TrainDetailsPanel.Visibility = OnTrainCheck.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(TrackNameText.Text))
+            {
+                MessageBox.Show("Veuillez saisir un nom de voie.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/PlaceDialog.xaml
+++ b/Ploco/Dialogs/PlaceDialog.xaml
@@ -1,0 +1,36 @@
+<Window x:Class="Ploco.Dialogs.PlaceDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Ajouter un lieu" Height="320" Width="420"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="12">
+        <TextBlock Text="Type de lieu" FontWeight="SemiBold"/>
+        <ComboBox x:Name="TypeCombo" Margin="0,6,0,12" SelectionChanged="TypeCombo_SelectionChanged">
+            <ComboBoxItem Content="Dépôt" Tag="Depot"/>
+            <ComboBoxItem Content="Garage" Tag="VoieGarage"/>
+            <ComboBoxItem Content="En ligne" Tag="ArretLigne"/>
+        </ComboBox>
+
+        <StackPanel x:Name="DepotPanel" Visibility="Collapsed">
+            <TextBlock Text="Nom du dépôt" FontWeight="SemiBold"/>
+            <ComboBox x:Name="DepotNameCombo" Margin="0,6,0,12"/>
+        </StackPanel>
+
+        <StackPanel x:Name="GaragePanel" Visibility="Collapsed">
+            <TextBlock Text="Nom du garage" FontWeight="SemiBold"/>
+            <ComboBox x:Name="GarageNameCombo" Margin="0,6,0,6" SelectionChanged="GarageNameCombo_SelectionChanged"/>
+            <TextBlock x:Name="CustomGarageLabel" Text="Nom personnalisé" FontWeight="SemiBold" Visibility="Collapsed"/>
+            <TextBox x:Name="CustomGarageName" Margin="0,6,0,12" Visibility="Collapsed"/>
+        </StackPanel>
+
+        <StackPanel x:Name="LinePanel" Visibility="Collapsed">
+            <TextBlock Text="Nom du lieu (en ligne)" FontWeight="SemiBold"/>
+            <TextBox x:Name="LineNameText" Margin="0,6,0,12"/>
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Ploco/Dialogs/PlaceDialog.xaml
+++ b/Ploco/Dialogs/PlaceDialog.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="Ploco.Dialogs.PlaceDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Ajouter un lieu" Height="320" Width="420"
+        Title="Ajouter un lieu" Height="260" Width="420"
         WindowStartupLocation="CenterOwner">
     <StackPanel Margin="12">
         <TextBlock Text="Type de lieu" FontWeight="SemiBold"/>
@@ -21,11 +21,6 @@
             <ComboBox x:Name="GarageNameCombo" Margin="0,6,0,6" SelectionChanged="GarageNameCombo_SelectionChanged"/>
             <TextBlock x:Name="CustomGarageLabel" Text="Nom personnalisé" FontWeight="SemiBold" Visibility="Collapsed"/>
             <TextBox x:Name="CustomGarageName" Margin="0,6,0,12" Visibility="Collapsed"/>
-        </StackPanel>
-
-        <StackPanel x:Name="LinePanel" Visibility="Collapsed">
-            <TextBlock Text="Nom du lieu (en ligne)" FontWeight="SemiBold"/>
-            <TextBox x:Name="LineNameText" Margin="0,6,0,12"/>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/Ploco/Dialogs/PlaceDialog.xaml.cs
+++ b/Ploco/Dialogs/PlaceDialog.xaml.cs
@@ -46,8 +46,6 @@ namespace Ploco.Dialogs
         {
             DepotPanel.Visibility = Visibility.Collapsed;
             GaragePanel.Visibility = Visibility.Collapsed;
-            LinePanel.Visibility = Visibility.Collapsed;
-
             if (TypeCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
             {
                 SelectedType = Enum.Parse<TileType>(tag);
@@ -64,8 +62,6 @@ namespace Ploco.Dialogs
                     GarageNameCombo.SelectedIndex = 0;
                     break;
                 case TileType.ArretLigne:
-                    LinePanel.Visibility = Visibility.Visible;
-                    LineNameText.Text = string.Empty;
                     break;
             }
         }
@@ -84,11 +80,11 @@ namespace Ploco.Dialogs
             {
                 TileType.Depot => DepotNameCombo.SelectedItem as string ?? string.Empty,
                 TileType.VoieGarage => ResolveGarageName(),
-                TileType.ArretLigne => LineNameText.Text.Trim(),
+                TileType.ArretLigne => string.Empty,
                 _ => string.Empty
             };
 
-            if (string.IsNullOrWhiteSpace(SelectedName))
+            if (SelectedType != TileType.ArretLigne && string.IsNullOrWhiteSpace(SelectedName))
             {
                 MessageBox.Show("Veuillez saisir un nom valide.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;

--- a/Ploco/Dialogs/PlaceDialog.xaml.cs
+++ b/Ploco/Dialogs/PlaceDialog.xaml.cs
@@ -21,6 +21,7 @@ namespace Ploco.Dialogs
             "Bale",
             "Bettembourg",
             "Chatelet",
+            "Gent",
             "La Louviere",
             "Luxembourg",
             "Monceau",

--- a/Ploco/Dialogs/PlaceDialog.xaml.cs
+++ b/Ploco/Dialogs/PlaceDialog.xaml.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class PlaceDialog : Window
+    {
+        private static readonly string[] DepotNames =
+        {
+            "Hausbergen",
+            "Mulhouse Nord",
+            "Thionville",
+            "Woippy"
+        };
+
+        private static readonly string[] GarageNames =
+        {
+            "Anvers Nord",
+            "Bale",
+            "Bettembourg",
+            "Chatelet",
+            "La Louviere",
+            "Luxembourg",
+            "Monceau",
+            "Ronet",
+            "SRH",
+            "Uckange",
+            "Zeebrugge",
+            "Autres"
+        };
+
+        public TileType SelectedType { get; private set; }
+        public string SelectedName { get; private set; } = string.Empty;
+
+        public PlaceDialog()
+        {
+            InitializeComponent();
+            DepotNameCombo.ItemsSource = DepotNames;
+            GarageNameCombo.ItemsSource = GarageNames;
+            TypeCombo.SelectedIndex = 0;
+        }
+
+        private void TypeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            DepotPanel.Visibility = Visibility.Collapsed;
+            GaragePanel.Visibility = Visibility.Collapsed;
+            LinePanel.Visibility = Visibility.Collapsed;
+
+            if (TypeCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                SelectedType = Enum.Parse<TileType>(tag);
+            }
+
+            switch (SelectedType)
+            {
+                case TileType.Depot:
+                    DepotPanel.Visibility = Visibility.Visible;
+                    DepotNameCombo.SelectedIndex = 0;
+                    break;
+                case TileType.VoieGarage:
+                    GaragePanel.Visibility = Visibility.Visible;
+                    GarageNameCombo.SelectedIndex = 0;
+                    break;
+                case TileType.ArretLigne:
+                    LinePanel.Visibility = Visibility.Visible;
+                    LineNameText.Text = string.Empty;
+                    break;
+            }
+        }
+
+        private void GarageNameCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var selected = GarageNameCombo.SelectedItem as string;
+            var showCustom = string.Equals(selected, "Autres");
+            CustomGarageLabel.Visibility = showCustom ? Visibility.Visible : Visibility.Collapsed;
+            CustomGarageName.Visibility = showCustom ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedName = SelectedType switch
+            {
+                TileType.Depot => DepotNameCombo.SelectedItem as string ?? string.Empty,
+                TileType.VoieGarage => ResolveGarageName(),
+                TileType.ArretLigne => LineNameText.Text.Trim(),
+                _ => string.Empty
+            };
+
+            if (string.IsNullOrWhiteSpace(SelectedName))
+            {
+                MessageBox.Show("Veuillez saisir un nom valide.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            DialogResult = true;
+        }
+
+        private string ResolveGarageName()
+        {
+            var selected = GarageNameCombo.SelectedItem as string ?? string.Empty;
+            if (string.Equals(selected, "Autres"))
+            {
+                return CustomGarageName.Text.Trim();
+            }
+
+            return selected;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/StatusDialog.xaml
+++ b/Ploco/Dialogs/StatusDialog.xaml
@@ -1,16 +1,27 @@
 <Window x:Class="Ploco.Dialogs.StatusDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Modifier statut" Height="200" Width="300"
+        Title="Modifier le statut" Height="320" Width="360"
         WindowStartupLocation="CenterOwner">
     <StackPanel Margin="12">
         <TextBlock x:Name="LocoLabel" Margin="0,0,0,10" FontWeight="Bold"/>
-        <ComboBox x:Name="StatusCombo" Margin="0,0,0,12">
-            <ComboBoxItem Content="Ok" Tag="Ok"/>
-            <ComboBoxItem Content="Défaut mineur" Tag="DefautMineur"/>
-            <ComboBoxItem Content="À contrôler" Tag="AControler"/>
+        <ComboBox x:Name="StatusCombo" Margin="0,0,0,12" SelectionChanged="StatusCombo_SelectionChanged">
+            <ComboBoxItem Content="OK" Tag="Ok"/>
+            <ComboBoxItem Content="Manque de traction" Tag="ManqueTraction"/>
             <ComboBoxItem Content="HS" Tag="HS"/>
         </ComboBox>
+
+        <StackPanel x:Name="TractionPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Nombre de moteurs HS sur 4" FontWeight="SemiBold"/>
+            <TextBox x:Name="TractionMotorsText" Margin="0,6,0,4"/>
+            <TextBlock x:Name="TractionHint" Foreground="SlateGray"/>
+        </StackPanel>
+
+        <StackPanel x:Name="HsPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Raison HS" FontWeight="SemiBold"/>
+            <TextBox x:Name="HsReasonText" Margin="0,6,0,0"/>
+        </StackPanel>
+
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
             <Button Content="Annuler" Width="80" Click="Cancel_Click"/>

--- a/Ploco/Dialogs/StatusDialog.xaml.cs
+++ b/Ploco/Dialogs/StatusDialog.xaml.cs
@@ -9,16 +9,20 @@ namespace Ploco.Dialogs
     {
         private readonly LocomotiveModel _locomotive;
 
-        public StatusDialog(LocomotiveModel locomotive)
+        public StatusDialog(LocomotiveModel locomotive, LocomotiveStatus? forcedStatus = null)
         {
             InitializeComponent();
             _locomotive = locomotive;
             LocoLabel.Text = locomotive.DisplayName;
-            StatusCombo.SelectedIndex = (int)locomotive.Status;
+            StatusCombo.SelectedIndex = (int)(forcedStatus ?? locomotive.Status);
             TractionMotorsText.Text = locomotive.TractionPercent.HasValue
                 ? TractionPercentToMotors(locomotive.TractionPercent.Value).ToString()
                 : string.Empty;
             HsReasonText.Text = locomotive.HsReason ?? string.Empty;
+            if (forcedStatus.HasValue)
+            {
+                StatusCombo.IsEnabled = false;
+            }
             UpdatePanels();
         }
 
@@ -56,7 +60,13 @@ namespace Ploco.Dialogs
 
                 if (status == LocomotiveStatus.HS)
                 {
-                    _locomotive.HsReason = string.IsNullOrWhiteSpace(HsReasonText.Text) ? null : HsReasonText.Text.Trim();
+                    if (string.IsNullOrWhiteSpace(HsReasonText.Text))
+                    {
+                        MessageBox.Show("Veuillez renseigner une raison HS.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
+
+                    _locomotive.HsReason = HsReasonText.Text.Trim();
                 }
                 else
                 {

--- a/Ploco/Dialogs/TapisT13Window.xaml
+++ b/Ploco/Dialogs/TapisT13Window.xaml
@@ -20,6 +20,7 @@
                 <TextBlock x:Name="SummaryText" Foreground="SlateGray"/>
             </StackPanel>
             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Actualiser" Margin="4,0" Click="Refresh_Click"/>
                 <Button Content="Copier colonne Locomotive" Margin="4,0" Click="CopyLocomotive_Click"/>
                 <Button Content="Copier colonne Loc HS" Margin="4,0" Click="CopyLocHs_Click"/>
                 <Button Content="Copier colonne Infos/Rapport" Margin="4,0" Click="CopyReport_Click"/>

--- a/Ploco/Dialogs/TapisT13Window.xaml
+++ b/Ploco/Dialogs/TapisT13Window.xaml
@@ -10,7 +10,21 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0" Text="Synthèse des locomotives T13 (pool Sibelit)" FontWeight="Bold" Margin="0,0,0,8"/>
+        <Grid Grid.Row="0" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0">
+                <TextBlock Text="Synthèse des locomotives T13 (pool Sibelit)" FontWeight="Bold"/>
+                <TextBlock x:Name="SummaryText" Foreground="SlateGray"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Copier colonne Locomotive" Margin="4,0" Click="CopyLocomotive_Click"/>
+                <Button Content="Copier colonne Loc HS" Margin="4,0" Click="CopyLocHs_Click"/>
+                <Button Content="Copier colonne Infos/Rapport" Margin="4,0" Click="CopyReport_Click"/>
+            </StackPanel>
+        </Grid>
 
         <DataGrid Grid.Row="1"
                   x:Name="T13Grid"
@@ -25,7 +39,7 @@
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Locomotive" Binding="{Binding Locomotive}" Width="*"/>
                 <DataGridTextColumn Header="Loc HS" Binding="{Binding LocHs}" Width="*"/>
-                <DataGridTextColumn Header="Infos / Report" Binding="{Binding Report}" Width="*"/>
+                <DataGridTextColumn Header="Infos / Rapport" Binding="{Binding Report}" Width="*"/>
             </DataGrid.Columns>
         </DataGrid>
 

--- a/Ploco/Dialogs/TapisT13Window.xaml
+++ b/Ploco/Dialogs/TapisT13Window.xaml
@@ -39,6 +39,7 @@
                   CanUserSortColumns="True">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Locomotive" Binding="{Binding Locomotive}" Width="*"/>
+                <DataGridTextColumn Header="Statut / Motif" Binding="{Binding Motif}" Width="*"/>
                 <DataGridTextColumn Header="Loc HS" Binding="{Binding LocHs}" Width="*"/>
                 <DataGridTextColumn Header="Infos / Rapport" Binding="{Binding Report}" Width="*"/>
             </DataGrid.Columns>

--- a/Ploco/Dialogs/TapisT13Window.xaml
+++ b/Ploco/Dialogs/TapisT13Window.xaml
@@ -1,0 +1,36 @@
+<Window x:Class="Ploco.Dialogs.TapisT13Window"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Tapis T13" Height="520" Width="680"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Synthèse des locomotives T13 (pool Sibelit)" FontWeight="Bold" Margin="0,0,0,8"/>
+
+        <DataGrid Grid.Row="1"
+                  x:Name="T13Grid"
+                  AutoGenerateColumns="False"
+                  HeadersVisibility="Column"
+                  IsReadOnly="True"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False"
+                  CanUserReorderColumns="False"
+                  CanUserResizeRows="False"
+                  CanUserSortColumns="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Locomotive" Binding="{Binding Locomotive}" Width="*"/>
+                <DataGridTextColumn Header="Loc HS" Binding="{Binding LocHs}" Width="*"/>
+                <DataGridTextColumn Header="Infos / Report" Binding="{Binding Report}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button Content="Fermer" Width="90" Click="Close_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class TapisT13Window : Window
+    {
+        private readonly ObservableCollection<T13Row> _rows = new();
+
+        public TapisT13Window(IEnumerable<LocomotiveModel> locomotives, IEnumerable<TileModel> tiles)
+        {
+            InitializeComponent();
+            T13Grid.ItemsSource = _rows;
+            LoadRows(locomotives, tiles);
+        }
+
+        private void LoadRows(IEnumerable<LocomotiveModel> locomotives, IEnumerable<TileModel> tiles)
+        {
+            _rows.Clear();
+            var tracks = tiles.SelectMany(tile => tile.Tracks).ToList();
+
+            foreach (var loco in locomotives
+                         .Where(l => IsT13(l) && string.Equals(l.Pool, "Sibelit", StringComparison.OrdinalIgnoreCase))
+                         .OrderBy(l => l.Number))
+            {
+                var track = tracks.FirstOrDefault(t => t.Locomotives.Contains(loco));
+                var location = ResolveLocation(track, tiles);
+                var trainInfo = track?.IsOnTrain == true
+                    ? string.IsNullOrWhiteSpace(track.TrainNumber)
+                        ? location
+                        : $"{location} {track.TrainNumber}"
+                    : location;
+
+                var locHs = loco.Status == LocomotiveStatus.HS ? trainInfo : string.Empty;
+                var report = loco.Status == LocomotiveStatus.HS ? trainInfo : string.Empty;
+
+                _rows.Add(new T13Row
+                {
+                    Locomotive = loco.Number.ToString(),
+                    LocHs = locHs,
+                    Report = report
+                });
+            }
+        }
+
+        private static bool IsT13(LocomotiveModel loco)
+        {
+            return loco.SeriesName.Contains("1300", StringComparison.OrdinalIgnoreCase)
+                   || loco.SeriesName.Contains("T13", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ResolveLocation(TrackModel? track, IEnumerable<TileModel> tiles)
+        {
+            if (track == null)
+            {
+                return string.Empty;
+            }
+
+            var tile = tiles.FirstOrDefault(t => t.Tracks.Contains(track));
+            if (tile == null)
+            {
+                return track.Name;
+            }
+
+            return GetLocationAbbreviation(tile.Name);
+        }
+
+        private static string GetLocationAbbreviation(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return name;
+            }
+
+            var normalized = name.Trim();
+            return normalized switch
+            {
+                "Thionville" => "THL",
+                "SRH" => "SRH",
+                "Anvers Nord" => "FN",
+                "Anvers" => "FN",
+                "Mulhouse Nord" => "MUN",
+                "Mulhouse" => "MUN",
+                "Bale" => "BAL",
+                "Woippy" => "WPY",
+                "Uckange" => "UCK",
+                "Zeebrugge" => "LZR",
+                "Gent" => "FGZH",
+                "Muizen" => "FIZ",
+                "Monceau" => "LNC",
+                "La Louviere" => "GLI",
+                "Chatelet" => "FCL",
+                _ => normalized
+            };
+        }
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private sealed class T13Row
+        {
+            public string Locomotive { get; set; } = string.Empty;
+            public string LocHs { get; set; } = string.Empty;
+            public string Report { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -35,16 +35,20 @@ namespace Ploco.Dialogs
                         : $"{location} {track.TrainNumber}"
                     : location;
 
-                var locHs = loco.Status == LocomotiveStatus.HS ? trainInfo : string.Empty;
-                var report = loco.Status == LocomotiveStatus.HS ? trainInfo : string.Empty;
+                var isHs = loco.Status == LocomotiveStatus.HS;
+                var locHs = isHs ? trainInfo : string.Empty;
+                var report = isHs ? trainInfo : string.Empty;
 
                 _rows.Add(new T13Row
                 {
                     Locomotive = loco.Number.ToString(),
                     LocHs = locHs,
-                    Report = report
+                    Report = report,
+                    IsHs = isHs
                 });
             }
+
+            UpdateSummary();
         }
 
         private static bool IsT13(LocomotiveModel loco)
@@ -103,11 +107,41 @@ namespace Ploco.Dialogs
             Close();
         }
 
+        private void CopyLocomotive_Click(object sender, RoutedEventArgs e)
+        {
+            CopyColumn(row => row.Locomotive);
+        }
+
+        private void CopyLocHs_Click(object sender, RoutedEventArgs e)
+        {
+            CopyColumn(row => row.LocHs);
+        }
+
+        private void CopyReport_Click(object sender, RoutedEventArgs e)
+        {
+            CopyColumn(row => row.Report);
+        }
+
+        private void CopyColumn(Func<T13Row, string> selector)
+        {
+            var text = string.Join(Environment.NewLine, _rows.Select(selector));
+            Clipboard.SetText(text);
+        }
+
+        private void UpdateSummary()
+        {
+            var total = _rows.Count;
+            var hsCount = _rows.Count(r => r.IsHs);
+            var okCount = total - hsCount;
+            SummaryText.Text = $"Total : {total} · HS : {hsCount} · OK : {okCount}";
+        }
+
         private sealed class T13Row
         {
             public string Locomotive { get; set; } = string.Empty;
             public string LocHs { get; set; } = string.Empty;
             public string Report { get; set; } = string.Empty;
+            public bool IsHs { get; set; }
         }
     }
 }

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -143,7 +143,17 @@ namespace Ploco.Dialogs
 
         public void RefreshData()
         {
+            var selected = T13Grid.SelectedItem as T13Row;
+            var selectedKey = selected?.Locomotive;
             LoadRows(_locomotives, _tiles);
+            if (!string.IsNullOrWhiteSpace(selectedKey))
+            {
+                var row = _rows.FirstOrDefault(item => item.Locomotive == selectedKey);
+                if (row != null)
+                {
+                    T13Grid.SelectedItem = row;
+                }
+            }
         }
 
         private sealed class T13Row

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -3,19 +3,24 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
+using Ploco.Helpers;
 using Ploco.Models;
 
 namespace Ploco.Dialogs
 {
-    public partial class TapisT13Window : Window
+    public partial class TapisT13Window : Window, IRefreshableWindow
     {
         private readonly ObservableCollection<T13Row> _rows = new();
+        private readonly IEnumerable<LocomotiveModel> _locomotives;
+        private readonly IEnumerable<TileModel> _tiles;
 
         public TapisT13Window(IEnumerable<LocomotiveModel> locomotives, IEnumerable<TileModel> tiles)
         {
             InitializeComponent();
             T13Grid.ItemsSource = _rows;
-            LoadRows(locomotives, tiles);
+            _locomotives = locomotives;
+            _tiles = tiles;
+            LoadRows(_locomotives, _tiles);
         }
 
         private void LoadRows(IEnumerable<LocomotiveModel> locomotives, IEnumerable<TileModel> tiles)
@@ -134,6 +139,11 @@ namespace Ploco.Dialogs
             var hsCount = _rows.Count(r => r.IsHs);
             var okCount = total - hsCount;
             SummaryText.Text = $"Total : {total} · HS : {hsCount} · OK : {okCount}";
+        }
+
+        public void RefreshData()
+        {
+            LoadRows(_locomotives, _tiles);
         }
 
         private sealed class T13Row

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -43,10 +43,12 @@ namespace Ploco.Dialogs
                 var isHs = loco.Status == LocomotiveStatus.HS;
                 var locHs = isHs ? trainInfo : string.Empty;
                 var report = isHs ? trainInfo : string.Empty;
+                var motif = isHs ? (loco.HsReason ?? string.Empty) : string.Empty;
 
                 _rows.Add(new T13Row
                 {
                     Locomotive = loco.Number.ToString(),
+                    Motif = motif,
                     LocHs = locHs,
                     Report = report,
                     IsHs = isHs
@@ -164,6 +166,7 @@ namespace Ploco.Dialogs
         private sealed class T13Row
         {
             public string Locomotive { get; set; } = string.Empty;
+            public string Motif { get; set; } = string.Empty;
             public string LocHs { get; set; } = string.Empty;
             public string Report { get; set; } = string.Empty;
             public bool IsHs { get; set; }

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -127,6 +127,11 @@ namespace Ploco.Dialogs
             CopyColumn(row => row.Report);
         }
 
+        private void Refresh_Click(object sender, RoutedEventArgs e)
+        {
+            RefreshData();
+        }
+
         private void CopyColumn(Func<T13Row, string> selector)
         {
             var text = string.Join(Environment.NewLine, _rows.Select(selector));

--- a/Ploco/Helpers/ContextMenuHelper.cs
+++ b/Ploco/Helpers/ContextMenuHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using Ploco.Dialogs;
 using Ploco.Models;
 
 namespace Ploco.Helpers

--- a/Ploco/Helpers/IRefreshableWindow.cs
+++ b/Ploco/Helpers/IRefreshableWindow.cs
@@ -1,0 +1,7 @@
+namespace Ploco.Helpers
+{
+    public interface IRefreshableWindow
+    {
+        void RefreshData();
+    }
+}

--- a/Ploco/Helpers/TileTemplateSelector.cs
+++ b/Ploco/Helpers/TileTemplateSelector.cs
@@ -1,0 +1,29 @@
+using System.Windows;
+using System.Windows.Controls;
+using Ploco.Models;
+
+namespace Ploco.Helpers
+{
+    public class TileTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate? DepotTemplate { get; set; }
+        public DataTemplate? GarageTemplate { get; set; }
+        public DataTemplate? LineTemplate { get; set; }
+
+        public override DataTemplate? SelectTemplate(object item, DependencyObject container)
+        {
+            if (item is not TileModel tile)
+            {
+                return base.SelectTemplate(item, container);
+            }
+
+            return tile.Type switch
+            {
+                TileType.Depot => DepotTemplate,
+                TileType.VoieGarage => GarageTemplate,
+                TileType.ArretLigne => LineTemplate,
+                _ => base.SelectTemplate(item, container)
+            };
+        }
+    }
+}

--- a/Ploco/HistoriqueWindow.xaml.cs
+++ b/Ploco/HistoriqueWindow.xaml.cs
@@ -1,17 +1,20 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
+using Ploco.Models;
 
 namespace Ploco
 {
     public partial class HistoriqueWindow : Window
     {
-        public HistoriqueWindow()
+        public HistoriqueWindow(IEnumerable<HistoryEntry> historyEntries)
         {
             InitializeComponent();
-            // Vérifie si le fichier log existe et le charge
-            if (File.Exists("StatutModificationLog.txt"))
+            var entries = historyEntries?.ToList() ?? new List<HistoryEntry>();
+            if (entries.Any())
             {
-                tbHistorique.Text = File.ReadAllText("StatutModificationLog.txt");
+                tbHistorique.Text = string.Join(Environment.NewLine, entries.Select(entry =>
+                    $"{entry.Timestamp:yyyy-MM-dd HH:mm:ss} | {entry.Action} | {entry.Details}"));
             }
             else
             {

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -715,6 +715,7 @@
             </MenuItem>
             <MenuItem Header="Option">
                 <MenuItem Header="Mode sombre" IsCheckable="True" Click="ToggleDarkMode_Click"/>
+                <MenuItem Header="Gestion base de données" Click="MenuItem_DatabaseManagement_Click"/>
                 <MenuItem Header="Réinitialiser">
                     <MenuItem Header="Réinitialiser locomotives" Click="MenuItem_ResetLocomotives_Click"/>
                     <MenuItem Header="Réinitialiser tuiles" Click="MenuItem_ResetTiles_Click"/>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -32,6 +32,10 @@
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
             <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         </Style>
+        <Style TargetType="ListBox">
+            <Setter Property="Background" Value="{DynamicResource ListBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ListBorderBrush}"/>
+        </Style>
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
         </Style>
@@ -41,6 +45,12 @@
             <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
         </Style>
         <Style TargetType="MenuItem">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource MenuBackgroundBrush}"/>
+        </Style>
+        <Style TargetType="ContextMenu">
+            <Setter Property="Background" Value="{DynamicResource MenuBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource MenuBorderBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
         </Style>
         <Style TargetType="ToolBar">

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -18,6 +18,11 @@
         <SolidColorBrush x:Key="TrackBorderBrush" Color="#FFE0E0E0"/>
         <SolidColorBrush x:Key="ListBackgroundBrush" Color="#FFF5F5F5"/>
         <SolidColorBrush x:Key="ListBorderBrush" Color="#FFDDDDDD"/>
+        <SolidColorBrush x:Key="AppForegroundBrush" Color="#FF111111"/>
+        <SolidColorBrush x:Key="MenuBackgroundBrush" Color="#FFF2F2F2"/>
+        <SolidColorBrush x:Key="MenuBorderBrush" Color="#FFDDDDDD"/>
+        <SolidColorBrush x:Key="ToolBarBackgroundBrush" Color="#FFF2F2F2"/>
+        <SolidColorBrush x:Key="ToolBarBorderBrush" Color="#FFDDDDDD"/>
         <Style x:Key="DropListBoxStyle" TargetType="ListBox">
             <Setter Property="MinHeight" Value="48"/>
             <Setter Property="Background" Value="{DynamicResource ListBackgroundBrush}"/>
@@ -26,6 +31,25 @@
             <Setter Property="Padding" Value="4"/>
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
             <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style TargetType="Menu">
+            <Setter Property="Background" Value="{DynamicResource MenuBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource MenuBorderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style TargetType="MenuItem">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style TargetType="ToolBar">
+            <Setter Property="Background" Value="{DynamicResource ToolBarBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ToolBarBorderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style TargetType="Button">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
         </Style>
         <Style x:Key="BlockedSwitchButtonBase" TargetType="Button">
             <Setter Property="MinWidth" Value="44"/>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -119,10 +119,14 @@
                                                     Padding="4" Margin="2" CornerRadius="4"
                                                     ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                 <Grid>
-                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                               HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                                                    <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                               HorizontalAlignment="Right" VerticalAlignment="Top">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                               HorizontalAlignment="Left"/>
+                                                    <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                               HorizontalAlignment="Right">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -181,10 +185,14 @@
                                                                         Padding="4" Margin="2" CornerRadius="4"
                                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                                     <Grid>
-                                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                                                   HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                                                                        <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                                   HorizontalAlignment="Right" VerticalAlignment="Top">
+                                                                        <Grid.RowDefinitions>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                        </Grid.RowDefinitions>
+                                                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                   HorizontalAlignment="Left"/>
+                                                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                   HorizontalAlignment="Right">
                                                                             <TextBlock.Style>
                                                                                 <Style TargetType="TextBlock">
                                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -283,10 +291,14 @@
                                                         Padding="4" Margin="2" CornerRadius="4"
                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                     <Grid>
-                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                                   HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                                                        <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                   HorizontalAlignment="Right" VerticalAlignment="Top">
+                                                        <Grid.RowDefinitions>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                        </Grid.RowDefinitions>
+                                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                   HorizontalAlignment="Left"/>
+                                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                   HorizontalAlignment="Right">
                                                             <TextBlock.Style>
                                                                 <Style TargetType="TextBlock">
                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -436,10 +448,14 @@
                                                                         Padding="4" Margin="2" CornerRadius="4"
                                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                                     <Grid>
-                                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                                                   HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                                                                        <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                                   HorizontalAlignment="Right" VerticalAlignment="Top">
+                                                                        <Grid.RowDefinitions>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                        </Grid.RowDefinitions>
+                                                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                   HorizontalAlignment="Left"/>
+                                                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                   HorizontalAlignment="Right">
                                                                             <TextBlock.Style>
                                                                                 <Style TargetType="TextBlock">
                                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -543,10 +559,14 @@
                                                                     Padding="4" Margin="2" CornerRadius="4"
                                                                     ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                                 <Grid>
-                                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                                               HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                                                                    <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                               HorizontalAlignment="Right" VerticalAlignment="Top">
+                                                                    <Grid.RowDefinitions>
+                                                                        <RowDefinition Height="Auto"/>
+                                                                        <RowDefinition Height="Auto"/>
+                                                                    </Grid.RowDefinitions>
+                                                                    <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                               HorizontalAlignment="Left"/>
+                                                                    <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                               HorizontalAlignment="Right">
                                                                         <TextBlock.Style>
                                                                             <Style TargetType="TextBlock">
                                                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -654,10 +674,14 @@
                                         Padding="6" Margin="4" CornerRadius="4"
                                         ContextMenu="{StaticResource LocomotiveListContextMenu}">
                                     <Grid>
-                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                   HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                                        <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                   HorizontalAlignment="Right" VerticalAlignment="Top">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                   HorizontalAlignment="Left"/>
+                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                   HorizontalAlignment="Right">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Setter Property="Visibility" Value="Visible"/>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -521,15 +521,19 @@
                 <MenuItem Header="Gestion des parcs" Click="MenuItem_PoolManagement_Click"/>
                 <MenuItem Header="Historique" Click="MenuItem_History_Click"/>
             </MenuItem>
-            <MenuItem Header="View">
+            <MenuItem Header="Tapis">
+                <MenuItem Header="T13" Click="MenuItem_TapisT13_Click"/>
+                <MenuItem Header="37000" IsEnabled="False"/>
+            </MenuItem>
+            <MenuItem Header="Vue">
                 <MenuItem Header="Charger un preset" x:Name="ViewPresetsMenu"/>
                 <MenuItem Header="Enregistrer le preset..." Click="SaveLayoutPreset_Click"/>
                 <MenuItem Header="Supprimer un preset" x:Name="ViewPresetsDeleteMenu"/>
             </MenuItem>
             <MenuItem Header="Option">
-                <MenuItem Header="Reset">
-                    <MenuItem Header="Reset locomotives" Click="MenuItem_ResetLocomotives_Click"/>
-                    <MenuItem Header="Reset tuiles" Click="MenuItem_ResetTiles_Click"/>
+                <MenuItem Header="Réinitialiser">
+                    <MenuItem Header="Réinitialiser locomotives" Click="MenuItem_ResetLocomotives_Click"/>
+                    <MenuItem Header="Réinitialiser tuiles" Click="MenuItem_ResetTiles_Click"/>
                 </MenuItem>
             </MenuItem>
         </Menu>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -448,6 +448,7 @@
                                                 <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold"/>
                                                 <Menu Grid.Column="1" HorizontalAlignment="Right">
                                                     <MenuItem Header="...">
+                                                        <MenuItem Header="Renommer voie" Click="RenameLineTrack_Click" Tag="{Binding}"/>
                                                         <MenuItem Header="Supprimer voie" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
                                                     </MenuItem>
                                                 </Menu>
@@ -513,6 +514,10 @@
             <MenuItem Header="Gestion">
                 <MenuItem Header="Gestion des parcs" Click="MenuItem_PoolManagement_Click"/>
                 <MenuItem Header="Historique" Click="MenuItem_History_Click"/>
+            </MenuItem>
+            <MenuItem Header="View">
+                <MenuItem Header="Charger un preset" x:Name="ViewPresetsMenu"/>
+                <MenuItem Header="Enregistrer le preset..." Click="SaveLayoutPreset_Click"/>
             </MenuItem>
             <MenuItem Header="Option">
                 <MenuItem Header="Reset">

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -119,10 +119,10 @@
                                                     Padding="4" Margin="2" CornerRadius="4"
                                                     ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                 <Grid>
-                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
-                                                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                               HorizontalAlignment="Left" VerticalAlignment="Top"/>
                                                     <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                               HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                               HorizontalAlignment="Right" VerticalAlignment="Top">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -181,10 +181,10 @@
                                                                         Padding="4" Margin="2" CornerRadius="4"
                                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                                     <Grid>
-                                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
-                                                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                   HorizontalAlignment="Left" VerticalAlignment="Top"/>
                                                                         <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                                                   HorizontalAlignment="Right" VerticalAlignment="Top">
                                                                             <TextBlock.Style>
                                                                                 <Style TargetType="TextBlock">
                                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -283,10 +283,10 @@
                                                         Padding="4" Margin="2" CornerRadius="4"
                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                     <Grid>
-                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
-                                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                   HorizontalAlignment="Left" VerticalAlignment="Top"/>
                                                         <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                                   HorizontalAlignment="Right" VerticalAlignment="Top">
                                                             <TextBlock.Style>
                                                                 <Style TargetType="TextBlock">
                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -436,10 +436,10 @@
                                                                         Padding="4" Margin="2" CornerRadius="4"
                                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                                     <Grid>
-                                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
-                                                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                   HorizontalAlignment="Left" VerticalAlignment="Top"/>
                                                                         <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                                                   HorizontalAlignment="Right" VerticalAlignment="Top">
                                                                             <TextBlock.Style>
                                                                                 <Style TargetType="TextBlock">
                                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -543,10 +543,10 @@
                                                                     Padding="4" Margin="2" CornerRadius="4"
                                                                     ContextMenu="{StaticResource LocomotiveTileContextMenu}">
                                                                 <Grid>
-                                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
-                                                                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                               HorizontalAlignment="Left" VerticalAlignment="Top"/>
                                                                     <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                               HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                                               HorizontalAlignment="Right" VerticalAlignment="Top">
                                                                         <TextBlock.Style>
                                                                             <Style TargetType="TextBlock">
                                                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -654,10 +654,10 @@
                                         Padding="6" Margin="4" CornerRadius="4"
                                         ContextMenu="{StaticResource LocomotiveListContextMenu}">
                                     <Grid>
-                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
-                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                   HorizontalAlignment="Left" VerticalAlignment="Top"/>
                                         <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                   HorizontalAlignment="Right" VerticalAlignment="Top">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Setter Property="Visibility" Value="Visible"/>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -63,30 +63,32 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
-                                    <DockPanel>
-                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
-                                        <TextBlock Text="Sortie" Foreground="SlateGray" DockPanel.Dock="Right" Margin="8,0,0,0"/>
-                                    </DockPanel>
-                                    <ListBox ItemsSource="{Binding Locomotives}"
-                                             AllowDrop="True"
-                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                             Drop="TrackLocomotives_Drop">
-                                        <ListBox.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <WrapPanel Orientation="Horizontal"/>
-                                            </ItemsPanelTemplate>
-                                        </ListBox.ItemsPanel>
-                                        <ListBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                        Padding="4" Margin="2" CornerRadius="4"
-                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                                </Border>
-                                            </DataTemplate>
-                                        </ListBox.ItemTemplate>
-                                    </ListBox>
+                                    <StackPanel>
+                                        <DockPanel>
+                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
+                                            <TextBlock Text="Sortie" Foreground="SlateGray" DockPanel.Dock="Right" Margin="8,0,0,0"/>
+                                        </DockPanel>
+                                        <ListBox ItemsSource="{Binding Locomotives}"
+                                                 AllowDrop="True"
+                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                 Drop="TrackLocomotives_Drop">
+                                            <ListBox.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Horizontal"/>
+                                                </ItemsPanelTemplate>
+                                            </ListBox.ItemsPanel>
+                                            <ListBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ListBox.ItemTemplate>
+                                        </ListBox>
+                                    </StackPanel>
                                 </Border>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -108,214 +108,45 @@
         </Style>
         <ContextMenu x:Key="LocomotiveTileContextMenu">
             <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
+            <MenuItem Header="Loc HS" Click="MenuItem_LocHs_Click" InputGestureText="Ctrl+H"/>
             <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
             <MenuItem Header="Retirer de la tuile" Click="MenuItem_RemoveFromTile_Click"/>
         </ContextMenu>
         <ContextMenu x:Key="LocomotiveListContextMenu">
             <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
+            <MenuItem Header="Loc HS" Click="MenuItem_LocHs_Click" InputGestureText="Ctrl+H"/>
             <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
         </ContextMenu>
         <DataTemplate x:Key="DepotTileTemplate">
             <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
-                    CornerRadius="6" Padding="8" Width="360" MinHeight="220"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="180"
                     AllowDrop="True"
                     Drop="Tile_Drop"
                     MouseLeftButtonDown="Tile_MouseLeftButtonDown"
                     MouseMove="Tile_MouseMove"
                     MouseLeftButtonUp="Tile_MouseLeftButtonUp">
-                <StackPanel>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <Menu Grid.Column="1" HorizontalAlignment="Right">
-                            <MenuItem Header="...">
-                                <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
-                                <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
-                                <Separator/>
-                                <MenuItem Header="Ajouter voie de sortie" Click="AddDepotOutput_Click" Tag="{Binding}"/>
-                            </MenuItem>
-                        </Menu>
-                    </Grid>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <StackPanel>
-                            <TextBlock Text="Locomotives" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
-                            <Grid>
-                                <ListBox x:Name="DepotMainList"
-                                         DataContext="{Binding MainTrack}"
-                                         ItemsSource="{Binding Locomotives}"
-                                         Style="{StaticResource DropListBoxStyle}"
-                                         AllowDrop="True"
-                                         PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                         PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                         Drop="TrackLocomotives_Drop">
-                                    <ListBox.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <WrapPanel Orientation="Horizontal"/>
-                                        </ItemsPanelTemplate>
-                                    </ListBox.ItemsPanel>
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                    Padding="4" Margin="2" CornerRadius="4"
-                                                    ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                <Grid>
-                                                    <Grid.RowDefinitions>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                    </Grid.RowDefinitions>
-                                                    <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                               HorizontalAlignment="Left"/>
-                                                    <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                               HorizontalAlignment="Right" Margin="0,2,0,0">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Visibility" Value="Visible"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding TractionDisplay}" Value="">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </Grid>
-                                            </Border>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                </ListBox>
-                                <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
-                                           HorizontalAlignment="Center" VerticalAlignment="Center">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding ElementName=DepotMainList, Path=HasItems}" Value="False">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                            </Grid>
-                            <ItemsControl ItemsSource="{Binding OutputTracks}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
-                                            <StackPanel>
-                                                <DockPanel>
-                                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
-                                                    <TextBlock Text="Sortie" Foreground="SlateGray" DockPanel.Dock="Right" Margin="8,0,0,0"/>
-                                                </DockPanel>
-                                                <Grid>
-                                                    <ListBox x:Name="DepotOutputList"
-                                                             ItemsSource="{Binding Locomotives}"
-                                                             Style="{StaticResource DropListBoxStyle}"
-                                                             AllowDrop="True"
-                                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                                             Drop="TrackLocomotives_Drop">
-                                                        <ListBox.ItemsPanel>
-                                                            <ItemsPanelTemplate>
-                                                                <WrapPanel Orientation="Horizontal"/>
-                                                            </ItemsPanelTemplate>
-                                                        </ListBox.ItemsPanel>
-                                                        <ListBox.ItemTemplate>
-                                                            <DataTemplate>
-                                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                                        Padding="4" Margin="2" CornerRadius="4"
-                                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                                    <Grid>
-                                                                        <Grid.RowDefinitions>
-                                                                            <RowDefinition Height="Auto"/>
-                                                                            <RowDefinition Height="Auto"/>
-                                                                        </Grid.RowDefinitions>
-                                                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                                                   HorizontalAlignment="Left"/>
-                                                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
-                                                                            <TextBlock.Style>
-                                                                                <Style TargetType="TextBlock">
-                                                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                                                    <Style.Triggers>
-                                                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
-                                                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                                                        </DataTrigger>
-                                                                                    </Style.Triggers>
-                                                                                </Style>
-                                                                            </TextBlock.Style>
-                                                                        </TextBlock>
-                                                                    </Grid>
-                                                                </Border>
-                                                            </DataTemplate>
-                                                        </ListBox.ItemTemplate>
-                                                    </ListBox>
-                                                    <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
-                                                               HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding ElementName=DepotOutputList, Path=HasItems}" Value="False">
-                                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </Grid>
-                                            </StackPanel>
-                                        </Border>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </ScrollViewer>
-                </StackPanel>
-            </Border>
-        </DataTemplate>
-        <DataTemplate x:Key="GarageTileTemplate">
-            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
-                    CornerRadius="6" Padding="8" Width="360" MinHeight="220"
-                    AllowDrop="True"
-                    Drop="Tile_Drop"
-                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
-                    MouseMove="Tile_MouseMove"
-                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
-                <StackPanel>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <Menu Grid.Column="1" HorizontalAlignment="Right">
-                            <MenuItem Header="...">
-                                <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
-                                <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
-                                <Separator/>
-                                <MenuItem Header="Ajouter zone" Click="AddGarageZone_Click" Tag="{Binding}"/>
-                            </MenuItem>
-                        </Menu>
-                    </Grid>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <StackPanel>
+                <Grid>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                            <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                <MenuItem Header="...">
+                                    <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Ajouter voie de sortie" Click="AddDepotOutput_Click" Tag="{Binding}"/>
+                                </MenuItem>
+                            </Menu>
+                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
                             <StackPanel>
-                                <StackPanel.Style>
-                                    <Style TargetType="StackPanel">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding MainTrack}" Value="{x:Null}">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </StackPanel.Style>
-                                <TextBlock Text="Zone principale" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                                <TextBlock Text="Locomotives" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
                                 <Grid>
-                                    <ListBox x:Name="GarageMainList"
+                                    <ListBox x:Name="DepotMainList"
                                              DataContext="{Binding MainTrack}"
                                              ItemsSource="{Binding Locomotives}"
                                              Style="{StaticResource DropListBoxStyle}"
@@ -364,7 +195,7 @@
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="Visibility" Value="Collapsed"/>
                                                 <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding ElementName=GarageMainList, Path=HasItems}" Value="False">
+                                                    <DataTrigger Binding="{Binding ElementName=DepotMainList, Path=HasItems}" Value="False">
                                                         <Setter Property="Visibility" Value="Visible"/>
                                                     </DataTrigger>
                                                 </Style.Triggers>
@@ -372,63 +203,282 @@
                                         </TextBlock.Style>
                                     </TextBlock>
                                 </Grid>
-                            </StackPanel>
-                            <ItemsControl ItemsSource="{Binding ZoneTracks}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
-                                            <StackPanel>
-                                                <Grid>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-                                                        <TextBlock Text="{Binding LeftLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                <ItemsControl ItemsSource="{Binding OutputTracks}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                                <StackPanel>
+                                                    <DockPanel>
+                                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
+                                                        <TextBlock Text="Sortie" Foreground="SlateGray" DockPanel.Dock="Right" Margin="8,0,0,0"/>
+                                                    </DockPanel>
+                                                    <Grid>
+                                                        <ListBox x:Name="DepotOutputList"
+                                                                 ItemsSource="{Binding Locomotives}"
+                                                                 Style="{StaticResource DropListBoxStyle}"
+                                                                 AllowDrop="True"
+                                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                                 Drop="TrackLocomotives_Drop">
+                                                            <ListBox.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                    <Canvas />
+                                                                </ItemsPanelTemplate>
+                                                            </ListBox.ItemsPanel>
+                                                            <ListBox.ItemContainerStyle>
+                                                                <Style TargetType="ListBoxItem">
+                                                                    <Setter Property="Canvas.Left" Value="{Binding AssignedTrackOffsetX, TargetNullValue=0}"/>
+                                                                    <Setter Property="Canvas.Top" Value="0"/>
+                                                                </Style>
+                                                            </ListBox.ItemContainerStyle>
+                                                            <ListBox.ItemTemplate>
+                                                                <DataTemplate>
+                                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                        <Grid>
+                                                                            <Grid.RowDefinitions>
+                                                                                <RowDefinition Height="Auto"/>
+                                                                                <RowDefinition Height="Auto"/>
+                                                                            </Grid.RowDefinitions>
+                                                                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                       HorizontalAlignment="Left"/>
+                                                                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                       HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                                <TextBlock.Style>
+                                                                                    <Style TargetType="TextBlock">
+                                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                                        <Style.Triggers>
+                                                                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                            </DataTrigger>
+                                                                                        </Style.Triggers>
+                                                                                    </Style>
+                                                                                </TextBlock.Style>
+                                                                            </TextBlock>
+                                                                        </Grid>
+                                                                    </Border>
+                                                                </DataTemplate>
+                                                            </ListBox.ItemTemplate>
+                                                        </ListBox>
+                                                        <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                                   HorizontalAlignment="Center" VerticalAlignment="Center">
                                                             <TextBlock.Style>
                                                                 <Style TargetType="TextBlock">
-                                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                                    <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                                        </DataTrigger>
-                                                                        <DataTrigger Binding="{Binding LeftLabel}" Value="">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                                        </DataTrigger>
-                                                                    </Style.Triggers>
-                                                                </Style>
-                                                            </TextBlock.Style>
-                                                        </TextBlock>
-                                                        <Button Style="{StaticResource LeftBlockedSwitchStyle}"
-                                                                Click="ToggleLeftBlocked_Click"/>
-                                                    </StackPanel>
-                                                    <Grid Grid.Column="1">
-                                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center">
-                                                            <TextBlock.Style>
-                                                                <Style TargetType="TextBlock">
-                                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                                    <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding Name}" Value="917">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                                        </DataTrigger>
-                                                                    </Style.Triggers>
-                                                                </Style>
-                                                            </TextBlock.Style>
-                                                        </TextBlock>
-                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                            <StackPanel.Style>
-                                                                <Style TargetType="StackPanel">
                                                                     <Setter Property="Visibility" Value="Collapsed"/>
                                                                     <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                        <DataTrigger Binding="{Binding ElementName=DepotOutputList, Path=HasItems}" Value="False">
                                                                             <Setter Property="Visibility" Value="Visible"/>
                                                                         </DataTrigger>
                                                                     </Style.Triggers>
                                                                 </Style>
-                                                            </StackPanel.Style>
-                                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="0,0,6,0"/>
-                                                            <Menu VerticalAlignment="Center">
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                    </Grid>
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </StackPanel>
+                    <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                           Cursor="SizeNWSE" DragDelta="TileResizeThumb_DragDelta" DragCompleted="TileResizeThumb_DragCompleted"
+                           Background="#55000000" BorderBrush="#FF7A7A7A" BorderThickness="1"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="GarageTileTemplate">
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="180"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <Grid>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                            <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                <MenuItem Header="...">
+                                    <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Ajouter zone" Click="AddGarageZone_Click" Tag="{Binding}"/>
+                                </MenuItem>
+                            </Menu>
+                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
+                                <StackPanel>
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding MainTrack}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
+                                    <TextBlock Text="Zone principale" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                                    <Grid>
+                                        <ListBox x:Name="GarageMainList"
+                                                 DataContext="{Binding MainTrack}"
+                                                 ItemsSource="{Binding Locomotives}"
+                                                 Style="{StaticResource DropListBoxStyle}"
+                                                 AllowDrop="True"
+                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                 Drop="TrackLocomotives_Drop">
+                                            <ListBox.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Horizontal"/>
+                                                </ItemsPanelTemplate>
+                                            </ListBox.ItemsPanel>
+                                            <ListBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                        <Grid>
+                                                            <Grid.RowDefinitions>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+                                                            </Grid.RowDefinitions>
+                                                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                       HorizontalAlignment="Left"/>
+                                                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                       HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ListBox.ItemTemplate>
+                                        </ListBox>
+                                        <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding ElementName=GarageMainList, Path=HasItems}" Value="False">
+                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </Grid>
+                                </StackPanel>
+                                <ItemsControl ItemsSource="{Binding ZoneTracks}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                                <StackPanel>
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                                            <TextBlock Text="{Binding LeftLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding LeftLabel}" Value="">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                            <Button Style="{StaticResource LeftBlockedSwitchStyle}"
+                                                                    Click="ToggleLeftBlocked_Click"/>
+                                                        </StackPanel>
+                                                        <Grid Grid.Column="1">
+                                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                                <StackPanel.Style>
+                                                                    <Style TargetType="StackPanel">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </StackPanel.Style>
+                                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="0,0,6,0"/>
+                                                                <Menu VerticalAlignment="Center">
+                                                                    <MenuItem Header="...">
+                                                                        <MenuItem Header="Renommer zone" Click="RenameZone_Click" Tag="{Binding}"/>
+                                                                        <MenuItem Header="Supprimer zone" Click="RemoveZone_Click" Tag="{Binding}"/>
+                                                                    </MenuItem>
+                                                                </Menu>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                        <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                            <Button Style="{StaticResource RightBlockedSwitchStyle}"
+                                                                    Click="ToggleRightBlocked_Click"/>
+                                                            <TextBlock Text="{Binding RightLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding RightLabel}" Value="">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                            <Menu HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                                <Menu.Style>
+                                                                    <Style TargetType="Menu">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </Menu.Style>
                                                                 <MenuItem Header="...">
                                                                     <MenuItem Header="Renommer zone" Click="RenameZone_Click" Tag="{Binding}"/>
                                                                     <MenuItem Header="Supprimer zone" Click="RemoveZone_Click" Tag="{Binding}"/>
@@ -436,44 +486,130 @@
                                                             </Menu>
                                                         </StackPanel>
                                                     </Grid>
-                                                    <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
-                                                        <Button Style="{StaticResource RightBlockedSwitchStyle}"
-                                                                Click="ToggleRightBlocked_Click"/>
-                                                        <TextBlock Text="{Binding RightLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                                    <Grid>
+                                                        <ListBox x:Name="GarageZoneList"
+                                                                 ItemsSource="{Binding Locomotives}"
+                                                                 Style="{StaticResource DropListBoxStyle}"
+                                                                 AllowDrop="True"
+                                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                                 Drop="TrackLocomotives_Drop">
+                                                            <ListBox.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                    <Canvas />
+                                                                </ItemsPanelTemplate>
+                                                            </ListBox.ItemsPanel>
+                                                            <ListBox.ItemContainerStyle>
+                                                                <Style TargetType="ListBoxItem">
+                                                                    <Setter Property="Canvas.Left" Value="{Binding AssignedTrackOffsetX, TargetNullValue=0}"/>
+                                                                    <Setter Property="Canvas.Top" Value="0"/>
+                                                                </Style>
+                                                            </ListBox.ItemContainerStyle>
+                                                            <ListBox.ItemTemplate>
+                                                                <DataTemplate>
+                                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                        <Grid>
+                                                                            <Grid.RowDefinitions>
+                                                                                <RowDefinition Height="Auto"/>
+                                                                                <RowDefinition Height="Auto"/>
+                                                                            </Grid.RowDefinitions>
+                                                                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                       HorizontalAlignment="Left"/>
+                                                                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                       HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                                <TextBlock.Style>
+                                                                                    <Style TargetType="TextBlock">
+                                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                                        <Style.Triggers>
+                                                                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                            </DataTrigger>
+                                                                                        </Style.Triggers>
+                                                                                    </Style>
+                                                                                </TextBlock.Style>
+                                                                            </TextBlock>
+                                                                        </Grid>
+                                                                    </Border>
+                                                                </DataTemplate>
+                                                            </ListBox.ItemTemplate>
+                                                        </ListBox>
+                                                        <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                                   HorizontalAlignment="Center" VerticalAlignment="Center">
                                                             <TextBlock.Style>
                                                                 <Style TargetType="TextBlock">
-                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
                                                                     <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                                        </DataTrigger>
-                                                                        <DataTrigger Binding="{Binding RightLabel}" Value="">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        <DataTrigger Binding="{Binding ElementName=GarageZoneList, Path=HasItems}" Value="False">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
                                                                         </DataTrigger>
                                                                     </Style.Triggers>
                                                                 </Style>
                                                             </TextBlock.Style>
                                                         </TextBlock>
-                                                        <Menu HorizontalAlignment="Right" VerticalAlignment="Center">
-                                                            <Menu.Style>
-                                                                <Style TargetType="Menu">
-                                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                                    <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding Name}" Value="917">
-                                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                                        </DataTrigger>
-                                                                    </Style.Triggers>
-                                                                </Style>
-                                                            </Menu.Style>
-                                                            <MenuItem Header="...">
-                                                                <MenuItem Header="Renommer zone" Click="RenameZone_Click" Tag="{Binding}"/>
-                                                                <MenuItem Header="Supprimer zone" Click="RemoveZone_Click" Tag="{Binding}"/>
-                                                            </MenuItem>
-                                                        </Menu>
-                                                    </StackPanel>
-                                                </Grid>
+                                                    </Grid>
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </StackPanel>
+                    <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                           Cursor="SizeNWSE" DragDelta="TileResizeThumb_DragDelta" DragCompleted="TileResizeThumb_DragCompleted"
+                           Background="#55000000" BorderBrush="#FF7A7A7A" BorderThickness="1"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="LineTileTemplate">
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="180"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <Grid>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                            <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                <MenuItem Header="...">
+                                    <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Ajouter voie" Click="AddLineTrack_Click" Tag="{Binding}"/>
+                                </MenuItem>
+                            </Menu>
+                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding LineTracks}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                            <StackPanel>
                                                 <Grid>
-                                                    <ListBox x:Name="GarageZoneList"
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold"/>
+                                                    <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                                        <MenuItem Header="...">
+                                                            <MenuItem Header="Renommer voie" Click="RenameLineTrack_Click" Tag="{Binding}"/>
+                                                            <MenuItem Header="Supprimer voie" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
+                                                        </MenuItem>
+                                                    </Menu>
+                                                </Grid>
+                                                <TextBlock Text="{Binding LineInfo}" FontSize="11" Foreground="SlateGray" Margin="0,2,0,4"/>
+                                                <Grid>
+                                                    <ListBox x:Name="LineTrackList"
                                                              ItemsSource="{Binding Locomotives}"
                                                              Style="{StaticResource DropListBoxStyle}"
                                                              AllowDrop="True"
@@ -482,9 +618,15 @@
                                                              Drop="TrackLocomotives_Drop">
                                                         <ListBox.ItemsPanel>
                                                             <ItemsPanelTemplate>
-                                                                <WrapPanel Orientation="Horizontal"/>
+                                                                <Canvas />
                                                             </ItemsPanelTemplate>
                                                         </ListBox.ItemsPanel>
+                                                        <ListBox.ItemContainerStyle>
+                                                            <Style TargetType="ListBoxItem">
+                                                                <Setter Property="Canvas.Left" Value="{Binding AssignedTrackOffsetX, TargetNullValue=0}"/>
+                                                                <Setter Property="Canvas.Top" Value="0"/>
+                                                            </Style>
+                                                        </ListBox.ItemContainerStyle>
                                                         <ListBox.ItemTemplate>
                                                             <DataTemplate>
                                                                 <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
@@ -521,7 +663,7 @@
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Visibility" Value="Collapsed"/>
                                                                 <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding ElementName=GarageZoneList, Path=HasItems}" Value="False">
+                                                                    <DataTrigger Binding="{Binding ElementName=LineTrackList, Path=HasItems}" Value="False">
                                                                         <Setter Property="Visibility" Value="Visible"/>
                                                                     </DataTrigger>
                                                                 </Style.Triggers>
@@ -534,119 +676,12 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
-                        </StackPanel>
-                    </ScrollViewer>
-                </StackPanel>
-            </Border>
-        </DataTemplate>
-        <DataTemplate x:Key="LineTileTemplate">
-            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
-                    CornerRadius="6" Padding="8" Width="360" MinHeight="220"
-                    AllowDrop="True"
-                    Drop="Tile_Drop"
-                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
-                    MouseMove="Tile_MouseMove"
-                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
-                <StackPanel>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <Menu Grid.Column="1" HorizontalAlignment="Right">
-                            <MenuItem Header="...">
-                                <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
-                                <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
-                                <Separator/>
-                                <MenuItem Header="Ajouter voie" Click="AddLineTrack_Click" Tag="{Binding}"/>
-                            </MenuItem>
-                        </Menu>
-                    </Grid>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <ItemsControl ItemsSource="{Binding LineTracks}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
-                                        <StackPanel>
-                                            <Grid>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold"/>
-                                                <Menu Grid.Column="1" HorizontalAlignment="Right">
-                                                    <MenuItem Header="...">
-                                                        <MenuItem Header="Renommer voie" Click="RenameLineTrack_Click" Tag="{Binding}"/>
-                                                        <MenuItem Header="Supprimer voie" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
-                                                    </MenuItem>
-                                                </Menu>
-                                            </Grid>
-                                            <TextBlock Text="{Binding LineInfo}" FontSize="11" Foreground="SlateGray" Margin="0,2,0,4"/>
-                                            <Grid>
-                                                <ListBox x:Name="LineTrackList"
-                                                         ItemsSource="{Binding Locomotives}"
-                                                         Style="{StaticResource DropListBoxStyle}"
-                                                         AllowDrop="True"
-                                                         PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                                         PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                                         Drop="TrackLocomotives_Drop">
-                                                    <ListBox.ItemsPanel>
-                                                        <ItemsPanelTemplate>
-                                                            <WrapPanel Orientation="Horizontal"/>
-                                                        </ItemsPanelTemplate>
-                                                    </ListBox.ItemsPanel>
-                                                    <ListBox.ItemTemplate>
-                                                        <DataTemplate>
-                                                            <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                                    Padding="4" Margin="2" CornerRadius="4"
-                                                                    ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                                <Grid>
-                                                                    <Grid.RowDefinitions>
-                                                                        <RowDefinition Height="Auto"/>
-                                                                        <RowDefinition Height="Auto"/>
-                                                                    </Grid.RowDefinitions>
-                                                                    <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                                                               HorizontalAlignment="Left"/>
-                                                                    <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                               HorizontalAlignment="Right" Margin="0,2,0,0">
-                                                                        <TextBlock.Style>
-                                                                            <Style TargetType="TextBlock">
-                                                                                <Setter Property="Visibility" Value="Visible"/>
-                                                                                <Style.Triggers>
-                                                                                    <DataTrigger Binding="{Binding TractionDisplay}" Value="">
-                                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                                    </DataTrigger>
-                                                                                </Style.Triggers>
-                                                                            </Style>
-                                                                        </TextBlock.Style>
-                                                                    </TextBlock>
-                                                                </Grid>
-                                                            </Border>
-                                                        </DataTemplate>
-                                                    </ListBox.ItemTemplate>
-                                                </ListBox>
-                                                <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
-                                                           HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                    <TextBlock.Style>
-                                                        <Style TargetType="TextBlock">
-                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding ElementName=LineTrackList, Path=HasItems}" Value="False">
-                                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </TextBlock.Style>
-                                                </TextBlock>
-                                            </Grid>
-                                        </StackPanel>
-                                    </Border>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </ScrollViewer>
-                </StackPanel>
+                        </ScrollViewer>
+                    </StackPanel>
+                    <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                           Cursor="SizeNWSE" DragDelta="TileResizeThumb_DragDelta" DragCompleted="TileResizeThumb_DragCompleted"
+                           Background="#55000000" BorderBrush="#FF7A7A7A" BorderThickness="1"/>
+                </Grid>
             </Border>
         </DataTemplate>
         <helpers:TileTemplateSelector x:Key="TileTemplateSelector"

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -633,6 +633,8 @@
                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                  ScrollViewer.VerticalScrollBarVisibility="Disabled"
                                  ScrollViewer.CanContentScroll="False"
+                                 AllowDrop="True"
+                                 Drop="LocomotiveList_Drop"
                                  PreviewMouseLeftButtonDown="LocomotiveList_PreviewMouseLeftButtonDown"
                                  PreviewMouseMove="LocomotiveList_PreviewMouseMove">
                         <ListBox.ItemsPanel>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Ploco.Converters"
+        xmlns:helpers="clr-namespace:Ploco.Helpers"
         Title="Ploco - Nouvelle version" Height="800" Width="1200"
         Icon="pack://application:,,,/img/train_logo.ico"
         Loaded="Window_Loaded" Closing="Window_Closing">
@@ -22,6 +23,205 @@
             <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
             <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
         </ContextMenu>
+        <DataTemplate x:Key="DepotTileTemplate">
+            <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="360"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <StackPanel>
+                    <DockPanel>
+                        <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                            <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
+                                    Click="RenameTile_Click" Tag="{Binding}"/>
+                            <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
+                                    Click="DeleteTile_Click" Tag="{Binding}"/>
+                        </StackPanel>
+                    </DockPanel>
+                    <TextBlock Text="Locomotives" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                    <ListBox DataContext="{Binding MainTrack}"
+                             ItemsSource="{Binding Locomotives}"
+                             AllowDrop="True"
+                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                             Drop="TrackLocomotives_Drop">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                        Padding="4" Margin="2" CornerRadius="4"
+                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                    <Button Content="Ajouter voie de sortie" Margin="0,6,0,4" Click="AddDepotOutput_Click" Tag="{Binding}"/>
+                    <ItemsControl ItemsSource="{Binding OutputTracks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
+                                    <DockPanel>
+                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
+                                        <TextBlock Text="Sortie" Foreground="SlateGray" DockPanel.Dock="Right" Margin="8,0,0,0"/>
+                                    </DockPanel>
+                                    <ListBox ItemsSource="{Binding Locomotives}"
+                                             AllowDrop="True"
+                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                             Drop="TrackLocomotives_Drop">
+                                        <ListBox.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ListBox.ItemsPanel>
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                        Padding="4" Margin="2" CornerRadius="4"
+                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="GarageTileTemplate">
+            <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="360"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <StackPanel>
+                    <DockPanel>
+                        <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                            <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
+                                    Click="RenameTile_Click" Tag="{Binding}"/>
+                            <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
+                                    Click="DeleteTile_Click" Tag="{Binding}"/>
+                        </StackPanel>
+                    </DockPanel>
+                    <TextBlock Text="Zone principale" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                    <ListBox DataContext="{Binding MainTrack}"
+                             ItemsSource="{Binding Locomotives}"
+                             AllowDrop="True"
+                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                             Drop="TrackLocomotives_Drop">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                        Padding="4" Margin="2" CornerRadius="4"
+                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                    <Button Content="Ajouter zone" Margin="0,6,0,4" Click="AddGarageZone_Click" Tag="{Binding}"/>
+                    <ItemsControl ItemsSource="{Binding ZoneTracks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
+                                    <DockPanel>
+                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                                            <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
+                                                    Click="RenameZone_Click" Tag="{Binding}"/>
+                                            <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
+                                                    Click="RemoveZone_Click" Tag="{Binding}"/>
+                                        </StackPanel>
+                                    </DockPanel>
+                                    <ListBox ItemsSource="{Binding Locomotives}"
+                                             AllowDrop="True"
+                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                             Drop="TrackLocomotives_Drop">
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                        Padding="4" Margin="2" CornerRadius="4"
+                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="LineTileTemplate">
+            <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="360"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <StackPanel>
+                    <DockPanel>
+                        <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                            <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
+                                    Click="RenameTile_Click" Tag="{Binding}"/>
+                            <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
+                                    Click="DeleteTile_Click" Tag="{Binding}"/>
+                        </StackPanel>
+                    </DockPanel>
+                    <Button Content="Ajouter voie" Margin="0,6,0,4" Click="AddLineTrack_Click" Tag="{Binding}"/>
+                    <ItemsControl ItemsSource="{Binding LineTracks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
+                                    <StackPanel>
+                                        <DockPanel>
+                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                            <Button DockPanel.Dock="Right" Style="{StaticResource TileHeaderButton}"
+                                                    Content="Supprimer" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
+                                        </DockPanel>
+                                        <TextBlock Text="{Binding LineInfo}" FontSize="11" Foreground="SlateGray" Margin="0,2,0,4"/>
+                                        <ListBox ItemsSource="{Binding Locomotives}"
+                                                 AllowDrop="True"
+                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                 Drop="TrackLocomotives_Drop">
+                                            <ListBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ListBox.ItemTemplate>
+                                        </ListBox>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+        <helpers:TileTemplateSelector x:Key="TileTemplateSelector"
+                                    DepotTemplate="{StaticResource DepotTileTemplate}"
+                                    GarageTemplate="{StaticResource GarageTileTemplate}"
+                                    LineTemplate="{StaticResource LineTileTemplate}"/>
     </Window.Resources>
     <DockPanel>
         <Menu DockPanel.Dock="Top">
@@ -38,9 +238,7 @@
             </MenuItem>
         </Menu>
         <ToolBar DockPanel.Dock="Top">
-            <Button Content="Ajouter dépôt" Click="AddDepot_Click"/>
-            <Button Content="Ajouter arrêt en ligne" Click="AddLineStop_Click"/>
-            <Button Content="Ajouter voie de garage" Click="AddGarage_Click"/>
+            <Button Content="Ajouter un lieu" Click="AddPlace_Click"/>
         </ToolBar>
         <Grid>
             <Grid.ColumnDefinitions>
@@ -53,6 +251,11 @@
                     <ListBox x:Name="LocomotiveList"
                              PreviewMouseLeftButtonDown="LocomotiveList_PreviewMouseLeftButtonDown"
                              PreviewMouseMove="LocomotiveList_PreviewMouseMove">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
                         <ListBox.ItemContainerStyle>
                             <Style TargetType="ListBoxItem">
                                 <Setter Property="Visibility"
@@ -88,74 +291,7 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
-                                        CornerRadius="6" Padding="8" Width="340"
-                                        AllowDrop="True"
-                                        Drop="Tile_Drop"
-                                        MouseLeftButtonDown="Tile_MouseLeftButtonDown"
-                                        MouseMove="Tile_MouseMove"
-                                        MouseLeftButtonUp="Tile_MouseLeftButtonUp">
-                                    <StackPanel>
-                                        <DockPanel>
-                                            <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="14"/>
-                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                                                <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
-                                                        Click="RenameTile_Click" Tag="{Binding}"/>
-                                                <Button Style="{StaticResource TileHeaderButton}" Content="Configurer"
-                                                        Click="ConfigureTile_Click" Tag="{Binding}"/>
-                                                <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
-                                                        Click="DeleteTile_Click" Tag="{Binding}"/>
-                                            </StackPanel>
-                                        </DockPanel>
-                                        <TextBlock Text="{Binding Type}" Foreground="Gray" FontSize="12" Margin="0,2,0,2"/>
-                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
-                                            <TextBlock Text="{Binding LocationPreset}" Foreground="SlateGray" FontSize="11"/>
-                                            <TextBlock Text="{Binding GarageTrackNumber, StringFormat= Voie {0}, TargetNullValue='', FallbackValue=''}"
-                                                       Foreground="SlateGray" FontSize="11" Margin="6,0,0,0"/>
-                                        </StackPanel>
-                                        <ItemsControl ItemsSource="{Binding Tracks}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
-                                                        <StackPanel>
-                                                            <DockPanel>
-                                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                                                                <Button DockPanel.Dock="Right" Style="{StaticResource TileHeaderButton}"
-                                                                        Content="Retirer voie" Click="RemoveTrack_Click"
-                                                                        Tag="{Binding}"/>
-                                                            </DockPanel>
-                                                            <ListBox ItemsSource="{Binding Locomotives}"
-                                                                     AllowDrop="True"
-                                                                     PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                                                     PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                                                     Drop="TrackLocomotives_Drop">
-                                                                <ListBox.ItemContainerStyle>
-                                                                    <Style TargetType="ListBoxItem">
-                                                                        <Setter Property="Visibility"
-                                                                                Value="{Binding IsVisibleInActivePool, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                                                    </Style>
-                                                                </ListBox.ItemContainerStyle>
-                                                                <ListBox.ItemTemplate>
-                                                                    <DataTemplate>
-                                                                        <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                                                Padding="4" Margin="2" CornerRadius="4"
-                                                                                ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                                            <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                                                        </Border>
-                                                                    </DataTemplate>
-                                                                </ListBox.ItemTemplate>
-                                                            </ListBox>
-                                                        </StackPanel>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                        <Button Content="Ajouter voie" Margin="0,4,0,0" Click="AddTrack_Click" Tag="{Binding}"/>
-                                        <Border Background="#FFF1F5FF" Padding="4" Margin="0,6,0,0" CornerRadius="4">
-                                            <TextBlock Text="Faites glisser les locomotives depuis la liste vers une voie." FontSize="11"/>
-                                        </Border>
-                                    </StackPanel>
-                                </Border>
+                                <ContentControl Content="{Binding}" ContentTemplateSelector="{StaticResource TileTemplateSelector}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -706,7 +706,6 @@
             </MenuItem>
             <MenuItem Header="Tapis">
                 <MenuItem Header="T13" Click="MenuItem_TapisT13_Click"/>
-                <MenuItem Header="Actualiser" Click="MenuItem_TapisRefresh_Click"/>
                 <MenuItem Header="37000" IsEnabled="False"/>
             </MenuItem>
             <MenuItem Header="Vue">

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -9,6 +9,15 @@
     <Window.Resources>
         <local:StatutToBrushConverter x:Key="StatutToBrushConverter"/>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <Style x:Key="DropListBoxStyle" TargetType="ListBox">
+            <Setter Property="MinHeight" Value="48"/>
+            <Setter Property="Background" Value="#FFF5F5F5"/>
+            <Setter Property="BorderBrush" Value="#FFDDDDDD"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
+        </Style>
         <Style x:Key="TileHeaderButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0,0,0"/>
             <Setter Property="Padding" Value="4,0"/>
@@ -25,7 +34,7 @@
         </ContextMenu>
         <DataTemplate x:Key="DepotTileTemplate">
             <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
-                    CornerRadius="6" Padding="8" Width="360"
+                    CornerRadius="6" Padding="8" Width="360" MinHeight="220"
                     AllowDrop="True"
                     Drop="Tile_Drop"
                     MouseLeftButtonDown="Tile_MouseLeftButtonDown"
@@ -34,71 +43,115 @@
                 <StackPanel>
                     <DockPanel>
                         <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                            <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
-                                    Click="RenameTile_Click" Tag="{Binding}"/>
-                            <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
-                                    Click="DeleteTile_Click" Tag="{Binding}"/>
-                        </StackPanel>
+                        <Menu DockPanel.Dock="Right">
+                            <MenuItem Header="...">
+                                <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                <Separator/>
+                                <MenuItem Header="Ajouter voie de sortie" Click="AddDepotOutput_Click" Tag="{Binding}"/>
+                            </MenuItem>
+                        </Menu>
                     </DockPanel>
-                    <TextBlock Text="Locomotives" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
-                    <ListBox DataContext="{Binding MainTrack}"
-                             ItemsSource="{Binding Locomotives}"
-                             AllowDrop="True"
-                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                             Drop="TrackLocomotives_Drop">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                        Padding="4" Margin="2" CornerRadius="4"
-                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                </Border>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                    <Button Content="Ajouter voie de sortie" Margin="0,6,0,4" Click="AddDepotOutput_Click" Tag="{Binding}"/>
-                    <ItemsControl ItemsSource="{Binding OutputTracks}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
-                                    <StackPanel>
-                                        <DockPanel>
-                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
-                                            <TextBlock Text="Sortie" Foreground="SlateGray" DockPanel.Dock="Right" Margin="8,0,0,0"/>
-                                        </DockPanel>
-                                        <ListBox ItemsSource="{Binding Locomotives}"
-                                                 AllowDrop="True"
-                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                                 Drop="TrackLocomotives_Drop">
-                                            <ListBox.ItemsPanel>
-                                                <ItemsPanelTemplate>
-                                                    <WrapPanel Orientation="Horizontal"/>
-                                                </ItemsPanelTemplate>
-                                            </ListBox.ItemsPanel>
-                                            <ListBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                            Padding="4" Margin="2" CornerRadius="4"
-                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ListBox.ItemTemplate>
-                                        </ListBox>
-                                    </StackPanel>
-                                </Border>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <TextBlock Text="Locomotives" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                            <Grid>
+                                <ListBox x:Name="DepotMainList"
+                                         DataContext="{Binding MainTrack}"
+                                         ItemsSource="{Binding Locomotives}"
+                                         Style="{StaticResource DropListBoxStyle}"
+                                         AllowDrop="True"
+                                         PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                         PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                         Drop="TrackLocomotives_Drop">
+                                    <ListBox.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <WrapPanel Orientation="Horizontal"/>
+                                        </ItemsPanelTemplate>
+                                    </ListBox.ItemsPanel>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                    Padding="4" Margin="2" CornerRadius="4"
+                                                    ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                                <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ElementName=DepotMainList, Path=HasItems}" Value="False">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Grid>
+                            <ItemsControl ItemsSource="{Binding OutputTracks}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                            <StackPanel>
+                                                <DockPanel>
+                                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
+                                                    <TextBlock Text="Sortie" Foreground="SlateGray" DockPanel.Dock="Right" Margin="8,0,0,0"/>
+                                                </DockPanel>
+                                                <Grid>
+                                                    <ListBox x:Name="DepotOutputList"
+                                                             ItemsSource="{Binding Locomotives}"
+                                                             Style="{StaticResource DropListBoxStyle}"
+                                                             AllowDrop="True"
+                                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                             Drop="TrackLocomotives_Drop">
+                                                        <ListBox.ItemsPanel>
+                                                            <ItemsPanelTemplate>
+                                                                <WrapPanel Orientation="Horizontal"/>
+                                                            </ItemsPanelTemplate>
+                                                        </ListBox.ItemsPanel>
+                                                        <ListBox.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                        Padding="4" Margin="2" CornerRadius="4"
+                                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ListBox.ItemTemplate>
+                                                    </ListBox>
+                                                    <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding ElementName=DepotOutputList, Path=HasItems}" Value="False">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Grid>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </ScrollViewer>
                 </StackPanel>
             </Border>
         </DataTemplate>
         <DataTemplate x:Key="GarageTileTemplate">
             <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
-                    CornerRadius="6" Padding="8" Width="360"
+                    CornerRadius="6" Padding="8" Width="360" MinHeight="220"
                     AllowDrop="True"
                     Drop="Tile_Drop"
                     MouseLeftButtonDown="Tile_MouseLeftButtonDown"
@@ -107,71 +160,150 @@
                 <StackPanel>
                     <DockPanel>
                         <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                            <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
-                                    Click="RenameTile_Click" Tag="{Binding}"/>
-                            <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
-                                    Click="DeleteTile_Click" Tag="{Binding}"/>
-                        </StackPanel>
+                        <Menu DockPanel.Dock="Right">
+                            <MenuItem Header="...">
+                                <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                <Separator/>
+                                <MenuItem Header="Ajouter zone" Click="AddGarageZone_Click" Tag="{Binding}"/>
+                            </MenuItem>
+                        </Menu>
                     </DockPanel>
-                    <TextBlock Text="Zone principale" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
-                    <ListBox DataContext="{Binding MainTrack}"
-                             ItemsSource="{Binding Locomotives}"
-                             AllowDrop="True"
-                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                             Drop="TrackLocomotives_Drop">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                        Padding="4" Margin="2" CornerRadius="4"
-                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                </Border>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                    <Button Content="Ajouter zone" Margin="0,6,0,4" Click="AddGarageZone_Click" Tag="{Binding}"/>
-                    <ItemsControl ItemsSource="{Binding ZoneTracks}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
-                                    <StackPanel>
-                                        <DockPanel>
-                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                                                <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
-                                                        Click="RenameZone_Click" Tag="{Binding}"/>
-                                                <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
-                                                        Click="RemoveZone_Click" Tag="{Binding}"/>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <TextBlock Text="Zone principale" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                            <Grid>
+                                <ListBox x:Name="GarageMainList"
+                                         DataContext="{Binding MainTrack}"
+                                         ItemsSource="{Binding Locomotives}"
+                                         Style="{StaticResource DropListBoxStyle}"
+                                         AllowDrop="True"
+                                         PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                         PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                         Drop="TrackLocomotives_Drop">
+                                    <ListBox.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <WrapPanel Orientation="Horizontal"/>
+                                        </ItemsPanelTemplate>
+                                    </ListBox.ItemsPanel>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                    Padding="4" Margin="2" CornerRadius="4"
+                                                    ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                                <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ElementName=GarageMainList, Path=HasItems}" Value="False">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Grid>
+                            <ItemsControl ItemsSource="{Binding ZoneTracks}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                            <StackPanel>
+                                                <DockPanel>
+                                                    <TextBlock Text="{Binding LeftLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding LeftLabel}" Value="">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="6,0,0,0"/>
+                                                    <TextBlock Text="{Binding RightLabel}" FontWeight="SemiBold" DockPanel.Dock="Right" Foreground="SlateGray">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding RightLabel}" Value="">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                                                        <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
+                                                                Click="RenameZone_Click" Tag="{Binding}"/>
+                                                        <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
+                                                                Click="RemoveZone_Click" Tag="{Binding}"/>
+                                                    </StackPanel>
+                                                </DockPanel>
+                                                <Grid>
+                                                    <ListBox x:Name="GarageZoneList"
+                                                             ItemsSource="{Binding Locomotives}"
+                                                             Style="{StaticResource DropListBoxStyle}"
+                                                             AllowDrop="True"
+                                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                             Drop="TrackLocomotives_Drop">
+                                                        <ListBox.ItemsPanel>
+                                                            <ItemsPanelTemplate>
+                                                                <WrapPanel Orientation="Horizontal"/>
+                                                            </ItemsPanelTemplate>
+                                                        </ListBox.ItemsPanel>
+                                                        <ListBox.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                        Padding="4" Margin="2" CornerRadius="4"
+                                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ListBox.ItemTemplate>
+                                                    </ListBox>
+                                                    <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding ElementName=GarageZoneList, Path=HasItems}" Value="False">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Grid>
                                             </StackPanel>
-                                        </DockPanel>
-                                        <ListBox ItemsSource="{Binding Locomotives}"
-                                                 AllowDrop="True"
-                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                                 Drop="TrackLocomotives_Drop">
-                                            <ListBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                            Padding="4" Margin="2" CornerRadius="4"
-                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ListBox.ItemTemplate>
-                                        </ListBox>
-                                    </StackPanel>
-                                </Border>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </ScrollViewer>
                 </StackPanel>
             </Border>
         </DataTemplate>
         <DataTemplate x:Key="LineTileTemplate">
             <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
-                    CornerRadius="6" Padding="8" Width="360"
+                    CornerRadius="6" Padding="8" Width="360" MinHeight="220"
                     AllowDrop="True"
                     Drop="Tile_Drop"
                     MouseLeftButtonDown="Tile_MouseLeftButtonDown"
@@ -180,45 +312,70 @@
                 <StackPanel>
                     <DockPanel>
                         <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                            <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
-                                    Click="RenameTile_Click" Tag="{Binding}"/>
-                            <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
-                                    Click="DeleteTile_Click" Tag="{Binding}"/>
-                        </StackPanel>
+                        <Menu DockPanel.Dock="Right">
+                            <MenuItem Header="...">
+                                <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                <Separator/>
+                                <MenuItem Header="Ajouter voie" Click="AddLineTrack_Click" Tag="{Binding}"/>
+                            </MenuItem>
+                        </Menu>
                     </DockPanel>
-                    <Button Content="Ajouter voie" Margin="0,6,0,4" Click="AddLineTrack_Click" Tag="{Binding}"/>
-                    <ItemsControl ItemsSource="{Binding LineTracks}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
-                                    <StackPanel>
-                                        <DockPanel>
-                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                                            <Button DockPanel.Dock="Right" Style="{StaticResource TileHeaderButton}"
-                                                    Content="Supprimer" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
-                                        </DockPanel>
-                                        <TextBlock Text="{Binding LineInfo}" FontSize="11" Foreground="SlateGray" Margin="0,2,0,4"/>
-                                        <ListBox ItemsSource="{Binding Locomotives}"
-                                                 AllowDrop="True"
-                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                                 Drop="TrackLocomotives_Drop">
-                                            <ListBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                            Padding="4" Margin="2" CornerRadius="4"
-                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ListBox.ItemTemplate>
-                                        </ListBox>
-                                    </StackPanel>
-                                </Border>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ItemsControl ItemsSource="{Binding LineTracks}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                        <StackPanel>
+                                            <DockPanel>
+                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                                <Button DockPanel.Dock="Right" Style="{StaticResource TileHeaderButton}"
+                                                        Content="Supprimer" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
+                                            </DockPanel>
+                                            <TextBlock Text="{Binding LineInfo}" FontSize="11" Foreground="SlateGray" Margin="0,2,0,4"/>
+                                            <Grid>
+                                                <ListBox x:Name="LineTrackList"
+                                                         ItemsSource="{Binding Locomotives}"
+                                                         Style="{StaticResource DropListBoxStyle}"
+                                                         AllowDrop="True"
+                                                         PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                         PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                         Drop="TrackLocomotives_Drop">
+                                                    <ListBox.ItemsPanel>
+                                                        <ItemsPanelTemplate>
+                                                            <WrapPanel Orientation="Horizontal"/>
+                                                        </ItemsPanelTemplate>
+                                                    </ListBox.ItemsPanel>
+                                                    <ListBox.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                    Padding="4" Margin="2" CornerRadius="4"
+                                                                    ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                            </Border>
+                                                        </DataTemplate>
+                                                    </ListBox.ItemTemplate>
+                                                </ListBox>
+                                                <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                           HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding ElementName=LineTrackList, Path=HasItems}" Value="False">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
                 </StackPanel>
             </Border>
         </DataTemplate>
@@ -238,7 +395,10 @@
                 <MenuItem Header="Historique" Click="MenuItem_History_Click"/>
             </MenuItem>
             <MenuItem Header="Option">
-                <MenuItem Header="Reset (debug)" Click="MenuItem_Reset_Click"/>
+                <MenuItem Header="Reset">
+                    <MenuItem Header="Reset locomotives" Click="MenuItem_ResetLocomotives_Click"/>
+                    <MenuItem Header="Reset tuiles" Click="MenuItem_ResetTiles_Click"/>
+                </MenuItem>
             </MenuItem>
         </Menu>
         <ToolBar DockPanel.Dock="Top">
@@ -252,9 +412,13 @@
             <Border Grid.Column="0" Margin="10" Background="#FFEFF4FF" CornerRadius="6">
                 <DockPanel>
                     <TextBlock DockPanel.Dock="Top" Text="Locomotives" FontWeight="Bold" Margin="8"/>
-                    <ListBox x:Name="LocomotiveList"
-                             PreviewMouseLeftButtonDown="LocomotiveList_PreviewMouseLeftButtonDown"
-                             PreviewMouseMove="LocomotiveList_PreviewMouseMove">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ListBox x:Name="LocomotiveList"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                 ScrollViewer.CanContentScroll="False"
+                                 PreviewMouseLeftButtonDown="LocomotiveList_PreviewMouseLeftButtonDown"
+                                 PreviewMouseMove="LocomotiveList_PreviewMouseMove">
                         <ListBox.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <WrapPanel />
@@ -276,7 +440,8 @@
                                 </Border>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
-                    </ListBox>
+                        </ListBox>
+                    </ScrollViewer>
                 </DockPanel>
             </Border>
             <Border Grid.Column="1" Margin="10" Background="#FFF7F7F7" CornerRadius="6">

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -29,7 +29,7 @@
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderBrush" Value="#FF1B5E20"/>
             <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="Content" Value="Free"/>
+            <Setter Property="Content" Value="Libre"/>
         </Style>
         <Style x:Key="LeftBlockedSwitchStyle" TargetType="Button" BasedOn="{StaticResource BlockedSwitchButtonBase}">
             <Setter Property="ToolTip" Value="BLOCK"/>
@@ -37,7 +37,7 @@
                 <DataTrigger Binding="{Binding IsLeftBlocked}" Value="True">
                     <Setter Property="Background" Value="#FFD32F2F"/>
                     <Setter Property="BorderBrush" Value="#FFB71C1C"/>
-                    <Setter Property="Content" Value="Full"/>
+                    <Setter Property="Content" Value="Plein"/>
                 </DataTrigger>
                 <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -53,7 +53,7 @@
                 <DataTrigger Binding="{Binding IsRightBlocked}" Value="True">
                     <Setter Property="Background" Value="#FFD32F2F"/>
                     <Setter Property="BorderBrush" Value="#FFB71C1C"/>
-                    <Setter Property="Content" Value="Full"/>
+                    <Setter Property="Content" Value="Plein"/>
                 </DataTrigger>
                 <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -118,7 +118,23 @@
                                             <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                     Padding="4" Margin="2" CornerRadius="4"
                                                     ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                <Grid>
+                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                    <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                               HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Grid>
                                             </Border>
                                         </DataTemplate>
                                     </ListBox.ItemTemplate>
@@ -164,7 +180,23 @@
                                                                 <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                                         Padding="4" Margin="2" CornerRadius="4"
                                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                                    <Grid>
+                                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
+                                                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                        <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                                            <TextBlock.Style>
+                                                                                <Style TargetType="TextBlock">
+                                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                                    <Style.Triggers>
+                                                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                        </DataTrigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </TextBlock.Style>
+                                                                        </TextBlock>
+                                                                    </Grid>
                                                                 </Border>
                                                             </DataTemplate>
                                                         </ListBox.ItemTemplate>
@@ -250,7 +282,23 @@
                                                 <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                         Padding="4" Margin="2" CornerRadius="4"
                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                    <Grid>
+                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
+                                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                    </Grid>
                                                 </Border>
                                             </DataTemplate>
                                         </ListBox.ItemTemplate>
@@ -387,7 +435,23 @@
                                                                 <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                                         Padding="4" Margin="2" CornerRadius="4"
                                                                         ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                                    <Grid>
+                                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
+                                                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                        <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                                            <TextBlock.Style>
+                                                                                <Style TargetType="TextBlock">
+                                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                                    <Style.Triggers>
+                                                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                        </DataTrigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </TextBlock.Style>
+                                                                        </TextBlock>
+                                                                    </Grid>
                                                                 </Border>
                                                             </DataTemplate>
                                                         </ListBox.ItemTemplate>
@@ -478,7 +542,23 @@
                                                             <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                                     Padding="4" Margin="2" CornerRadius="4"
                                                                     ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                                <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                                <Grid>
+                                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
+                                                                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                    <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                               HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                                                        <TextBlock.Style>
+                                                                            <Style TargetType="TextBlock">
+                                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                                <Style.Triggers>
+                                                                                    <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                    </DataTrigger>
+                                                                                </Style.Triggers>
+                                                                            </Style>
+                                                                        </TextBlock.Style>
+                                                                    </TextBlock>
+                                                                </Grid>
                                                             </Border>
                                                         </DataTemplate>
                                                     </ListBox.ItemTemplate>
@@ -571,8 +651,23 @@
                                 <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                         Padding="6" Margin="4" CornerRadius="4"
                                         ContextMenu="{StaticResource LocomotiveListContextMenu}">
-                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
-                                               HorizontalAlignment="Center"/>
+                                    <Grid>
+                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </Grid>
                                 </Border>
                             </DataTemplate>
                         </ListBox.ItemTemplate>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -5,14 +5,23 @@
         xmlns:helpers="clr-namespace:Ploco.Helpers"
         Title="Ploco - Nouvelle version" Height="800" Width="1200"
         Icon="pack://application:,,,/img/train_logo.ico"
+        Background="{DynamicResource AppBackgroundBrush}"
         Loaded="Window_Loaded" Closing="Window_Closing">
     <Window.Resources>
         <local:StatutToBrushConverter x:Key="StatutToBrushConverter"/>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <SolidColorBrush x:Key="AppBackgroundBrush" Color="#FFF2F2F2"/>
+        <SolidColorBrush x:Key="PanelBackgroundBrush" Color="#FFEFF4FF"/>
+        <SolidColorBrush x:Key="CanvasBackgroundBrush" Color="#FFF7F7F7"/>
+        <SolidColorBrush x:Key="TileBackgroundBrush" Color="White"/>
+        <SolidColorBrush x:Key="TileBorderBrush" Color="#FFB0B0B0"/>
+        <SolidColorBrush x:Key="TrackBorderBrush" Color="#FFE0E0E0"/>
+        <SolidColorBrush x:Key="ListBackgroundBrush" Color="#FFF5F5F5"/>
+        <SolidColorBrush x:Key="ListBorderBrush" Color="#FFDDDDDD"/>
         <Style x:Key="DropListBoxStyle" TargetType="ListBox">
             <Setter Property="MinHeight" Value="48"/>
-            <Setter Property="Background" Value="#FFF5F5F5"/>
-            <Setter Property="BorderBrush" Value="#FFDDDDDD"/>
+            <Setter Property="Background" Value="{DynamicResource ListBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ListBorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Padding" Value="4"/>
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
@@ -73,7 +82,7 @@
             <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
         </ContextMenu>
         <DataTemplate x:Key="DepotTileTemplate">
-            <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
                     CornerRadius="6" Padding="8" Width="360" MinHeight="220"
                     AllowDrop="True"
                     Drop="Tile_Drop"
@@ -126,7 +135,7 @@
                                                     <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
                                                                HorizontalAlignment="Left"/>
                                                     <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                               HorizontalAlignment="Right">
+                                                               HorizontalAlignment="Right" Margin="0,2,0,0">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -160,7 +169,7 @@
                             <ItemsControl ItemsSource="{Binding OutputTracks}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
                                             <StackPanel>
                                                 <DockPanel>
                                                     <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
@@ -192,7 +201,7 @@
                                                                         <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
                                                                                    HorizontalAlignment="Left"/>
                                                                         <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                                   HorizontalAlignment="Right">
+                                                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
                                                                             <TextBlock.Style>
                                                                                 <Style TargetType="TextBlock">
                                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -234,7 +243,7 @@
             </Border>
         </DataTemplate>
         <DataTemplate x:Key="GarageTileTemplate">
-            <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
                     CornerRadius="6" Padding="8" Width="360" MinHeight="220"
                     AllowDrop="True"
                     Drop="Tile_Drop"
@@ -298,7 +307,7 @@
                                                         <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
                                                                    HorizontalAlignment="Left"/>
                                                         <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                   HorizontalAlignment="Right">
+                                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
                                                             <TextBlock.Style>
                                                                 <Style TargetType="TextBlock">
                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -333,7 +342,7 @@
                             <ItemsControl ItemsSource="{Binding ZoneTracks}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
                                             <StackPanel>
                                                 <Grid>
                                                     <Grid.ColumnDefinitions>
@@ -455,7 +464,7 @@
                                                                         <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
                                                                                    HorizontalAlignment="Left"/>
                                                                         <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                                   HorizontalAlignment="Right">
+                                                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
                                                                             <TextBlock.Style>
                                                                                 <Style TargetType="TextBlock">
                                                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -497,7 +506,7 @@
             </Border>
         </DataTemplate>
         <DataTemplate x:Key="LineTileTemplate">
-            <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
                     CornerRadius="6" Padding="8" Width="360" MinHeight="220"
                     AllowDrop="True"
                     Drop="Tile_Drop"
@@ -524,7 +533,7 @@
                         <ItemsControl ItemsSource="{Binding LineTracks}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                    <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
                                         <StackPanel>
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
@@ -566,7 +575,7 @@
                                                                     <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
                                                                                HorizontalAlignment="Left"/>
                                                                     <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                                               HorizontalAlignment="Right">
+                                                                               HorizontalAlignment="Right" Margin="0,2,0,0">
                                                                         <TextBlock.Style>
                                                                             <Style TargetType="TextBlock">
                                                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -631,6 +640,7 @@
                 <MenuItem Header="Supprimer un preset" x:Name="ViewPresetsDeleteMenu"/>
             </MenuItem>
             <MenuItem Header="Option">
+                <MenuItem Header="Mode sombre" IsCheckable="True" Click="ToggleDarkMode_Click"/>
                 <MenuItem Header="Réinitialiser">
                     <MenuItem Header="Réinitialiser locomotives" Click="MenuItem_ResetLocomotives_Click"/>
                     <MenuItem Header="Réinitialiser tuiles" Click="MenuItem_ResetTiles_Click"/>
@@ -645,7 +655,7 @@
                 <ColumnDefinition Width="260"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <Border Grid.Column="0" Margin="10" Background="#FFEFF4FF" CornerRadius="6">
+            <Border Grid.Column="0" Margin="10" Background="{DynamicResource PanelBackgroundBrush}" CornerRadius="6">
                 <DockPanel>
                     <TextBlock DockPanel.Dock="Top" Text="Locomotives" FontWeight="Bold" Margin="8"/>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -681,7 +691,7 @@
                                         <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
                                                    HorizontalAlignment="Left"/>
                                         <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                                   HorizontalAlignment="Right">
+                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -701,7 +711,7 @@
                     </ScrollViewer>
                 </DockPanel>
             </Border>
-            <Border Grid.Column="1" Margin="10" Background="#FFF7F7F7" CornerRadius="6">
+            <Border Grid.Column="1" Margin="10" Background="{DynamicResource CanvasBackgroundBrush}" CornerRadius="6">
                 <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                     <ItemsControl x:Name="TileCanvas">
                         <ItemsControl.ItemsPanel>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -31,6 +31,28 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+        <Style x:Key="LeftBlockedToggleStyle" TargetType="ToggleButton" BasedOn="{StaticResource SaturationToggleStyle}">
+            <Setter Property="ToolTip" Value="BLOCK plein"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding LeftLabel}" Value="">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="RightBlockedToggleStyle" TargetType="ToggleButton" BasedOn="{StaticResource SaturationToggleStyle}">
+            <Setter Property="ToolTip" Value="BIF plein"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding RightLabel}" Value="">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
         <Style x:Key="TileHeaderButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0,0,0"/>
             <Setter Property="Padding" Value="4,0"/>
@@ -272,39 +294,11 @@
                                                             </Style>
                                                         </TextBlock.Style>
                                                     </TextBlock>
-                                                    <ToggleButton Style="{StaticResource SaturationToggleStyle}"
+                                                    <ToggleButton Style="{StaticResource RightBlockedToggleStyle}"
                                                                   DockPanel.Dock="Right"
-                                                                  IsChecked="{Binding IsRightBlocked}"
-                                                                  ToolTip="BIF plein">
-                                                        <ToggleButton.Style>
-                                                            <Style TargetType="ToggleButton" BasedOn="{StaticResource SaturationToggleStyle}">
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                    <DataTrigger Binding="{Binding RightLabel}" Value="">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </ToggleButton.Style>
-                                                    </ToggleButton>
-                                                    <ToggleButton Style="{StaticResource SaturationToggleStyle}"
-                                                                  IsChecked="{Binding IsLeftBlocked}"
-                                                                  ToolTip="BLOCK plein">
-                                                        <ToggleButton.Style>
-                                                            <Style TargetType="ToggleButton" BasedOn="{StaticResource SaturationToggleStyle}">
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                    <DataTrigger Binding="{Binding LeftLabel}" Value="">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </ToggleButton.Style>
-                                                    </ToggleButton>
+                                                                  IsChecked="{Binding IsRightBlocked}"/>
+                                                    <ToggleButton Style="{StaticResource LeftBlockedToggleStyle}"
+                                                                  IsChecked="{Binding IsLeftBlocked}"/>
                                                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                                                         <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
                                                                 Click="RenameZone_Click" Tag="{Binding}"/>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -161,9 +161,10 @@
                                         </ListBox.ItemsPanel>
                                         <ListBox.ItemTemplate>
                                             <DataTemplate>
-                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                        Padding="4" Margin="2" CornerRadius="4"
-                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                            <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                    Padding="4" Margin="2" CornerRadius="4"
+                                                    ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                    PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
                                                     <Grid>
                                                         <Grid.RowDefinitions>
                                                             <RowDefinition Height="Auto"/>
@@ -235,7 +236,8 @@
                                                                 <DataTemplate>
                                                                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                                             Padding="4" Margin="2" CornerRadius="4"
-                                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                                            PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
                                                                         <Grid>
                                                                             <Grid.RowDefinitions>
                                                                                 <RowDefinition Height="Auto"/>
@@ -346,7 +348,8 @@
                                                 <DataTemplate>
                                                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                             Padding="4" Margin="2" CornerRadius="4"
-                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                            PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
                                                         <Grid>
                                                             <Grid.RowDefinitions>
                                                                 <RowDefinition Height="Auto"/>
@@ -509,7 +512,8 @@
                                                                 <DataTemplate>
                                                                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                                             Padding="4" Margin="2" CornerRadius="4"
-                                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                                            PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
                                                                         <Grid>
                                                                             <Grid.RowDefinitions>
                                                                                 <RowDefinition Height="Auto"/>
@@ -631,7 +635,8 @@
                                                             <DataTemplate>
                                                                 <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                                         Padding="4" Margin="2" CornerRadius="4"
-                                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                                        PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
                                                                     <Grid>
                                                                         <Grid.RowDefinitions>
                                                                             <RowDefinition Height="Auto"/>
@@ -751,7 +756,8 @@
                             <DataTemplate>
                                 <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                         Padding="6" Margin="4" CornerRadius="4"
-                                        ContextMenu="{StaticResource LocomotiveListContextMenu}">
+                                        ContextMenu="{StaticResource LocomotiveListContextMenu}"
+                                        PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -7,17 +7,36 @@
         Loaded="Window_Loaded" Closing="Window_Closing">
     <Window.Resources>
         <local:StatutToBrushConverter x:Key="StatutToBrushConverter"/>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <Style x:Key="TileHeaderButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0,0,0"/>
             <Setter Property="Padding" Value="4,0"/>
             <Setter Property="FontSize" Value="11"/>
         </Style>
-        <ContextMenu x:Key="LocomotiveContextMenu">
+        <ContextMenu x:Key="LocomotiveTileContextMenu">
             <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
+            <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
             <MenuItem Header="Retirer de la tuile" Click="MenuItem_RemoveFromTile_Click"/>
+        </ContextMenu>
+        <ContextMenu x:Key="LocomotiveListContextMenu">
+            <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
+            <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
         </ContextMenu>
     </Window.Resources>
     <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="Fichier">
+                <MenuItem Header="Sauvegarder" Click="MenuItem_Save_Click"/>
+                <MenuItem Header="Charger" Click="MenuItem_Load_Click"/>
+            </MenuItem>
+            <MenuItem Header="Gestion">
+                <MenuItem Header="Gestion des parcs" Click="MenuItem_PoolManagement_Click"/>
+                <MenuItem Header="Historique" Click="MenuItem_History_Click"/>
+            </MenuItem>
+            <MenuItem Header="Option">
+                <MenuItem Header="Reset (debug)" Click="MenuItem_Reset_Click"/>
+            </MenuItem>
+        </Menu>
         <ToolBar DockPanel.Dock="Top">
             <Button Content="Ajouter dépôt" Click="AddDepot_Click"/>
             <Button Content="Ajouter arrêt en ligne" Click="AddLineStop_Click"/>
@@ -32,9 +51,25 @@
                 <DockPanel>
                     <TextBlock DockPanel.Dock="Top" Text="Locomotives" FontWeight="Bold" Margin="8"/>
                     <ListBox x:Name="LocomotiveList"
-                             DisplayMemberPath="DisplayName"
                              PreviewMouseLeftButtonDown="LocomotiveList_PreviewMouseLeftButtonDown"
-                             PreviewMouseMove="LocomotiveList_PreviewMouseMove"/>
+                             PreviewMouseMove="LocomotiveList_PreviewMouseMove">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Visibility"
+                                        Value="{Binding IsVisibleInActivePool, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                        Padding="6" Margin="4" CornerRadius="4"
+                                        ContextMenu="{StaticResource LocomotiveListContextMenu}">
+                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"
+                                               HorizontalAlignment="Center"/>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                 </DockPanel>
             </Border>
             <Border Grid.Column="1" Margin="10" Background="#FFF7F7F7" CornerRadius="6">
@@ -90,17 +125,22 @@
                                                                         Tag="{Binding}"/>
                                                             </DockPanel>
                                                             <ListBox ItemsSource="{Binding Locomotives}"
-                                                                     DisplayMemberPath="DisplayName"
                                                                      AllowDrop="True"
                                                                      PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
                                                                      PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
                                                                      Drop="TrackLocomotives_Drop">
+                                                                <ListBox.ItemContainerStyle>
+                                                                    <Style TargetType="ListBoxItem">
+                                                                        <Setter Property="Visibility"
+                                                                                Value="{Binding IsVisibleInActivePool, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                                                    </Style>
+                                                                </ListBox.ItemContainerStyle>
                                                                 <ListBox.ItemTemplate>
                                                                     <DataTemplate>
                                                                         <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                                                                                 Padding="4" Margin="2" CornerRadius="4"
-                                                                                ContextMenu="{StaticResource LocomotiveContextMenu}">
-                                                                            <TextBlock Text="{Binding DisplayName}" Foreground="White" FontWeight="Bold"/>
+                                                                                ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                                            <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
                                                                         </Border>
                                                                     </DataTemplate>
                                                                 </ListBox.ItemTemplate>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -18,6 +18,19 @@
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
             <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         </Style>
+        <Style x:Key="SaturationToggleStyle" TargetType="ToggleButton">
+            <Setter Property="Width" Value="12"/>
+            <Setter Property="Height" Value="12"/>
+            <Setter Property="Margin" Value="4,0,0,0"/>
+            <Setter Property="Background" Value="#FFDDDDDD"/>
+            <Setter Property="BorderBrush" Value="#FF888888"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Style.Triggers>
+                <Trigger Property="IsChecked" Value="True">
+                    <Setter Property="Background" Value="#FFD32F2F"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
         <Style x:Key="TileHeaderButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0,0,0"/>
             <Setter Property="Padding" Value="4,0"/>
@@ -171,45 +184,57 @@
                     </DockPanel>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <StackPanel>
-                            <TextBlock Text="Zone principale" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
-                            <Grid>
-                                <ListBox x:Name="GarageMainList"
-                                         DataContext="{Binding MainTrack}"
-                                         ItemsSource="{Binding Locomotives}"
-                                         Style="{StaticResource DropListBoxStyle}"
-                                         AllowDrop="True"
-                                         PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                         PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                         Drop="TrackLocomotives_Drop">
-                                    <ListBox.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <WrapPanel Orientation="Horizontal"/>
-                                        </ItemsPanelTemplate>
-                                    </ListBox.ItemsPanel>
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                    Padding="4" Margin="2" CornerRadius="4"
-                                                    ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                            </Border>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                </ListBox>
-                                <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
-                                           HorizontalAlignment="Center" VerticalAlignment="Center">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding ElementName=GarageMainList, Path=HasItems}" Value="False">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                            </Grid>
+                            <StackPanel>
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding MainTrack}" Value="{x:Null}">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock Text="Zone principale" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                                <Grid>
+                                    <ListBox x:Name="GarageMainList"
+                                             DataContext="{Binding MainTrack}"
+                                             ItemsSource="{Binding Locomotives}"
+                                             Style="{StaticResource DropListBoxStyle}"
+                                             AllowDrop="True"
+                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                             Drop="TrackLocomotives_Drop">
+                                        <ListBox.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ListBox.ItemsPanel>
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                        Padding="4" Margin="2" CornerRadius="4"
+                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                    <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding ElementName=GarageMainList, Path=HasItems}" Value="False">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                            </StackPanel>
                             <ItemsControl ItemsSource="{Binding ZoneTracks}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
@@ -247,6 +272,39 @@
                                                             </Style>
                                                         </TextBlock.Style>
                                                     </TextBlock>
+                                                    <ToggleButton Style="{StaticResource SaturationToggleStyle}"
+                                                                  DockPanel.Dock="Right"
+                                                                  IsChecked="{Binding IsRightBlocked}"
+                                                                  ToolTip="BIF plein">
+                                                        <ToggleButton.Style>
+                                                            <Style TargetType="ToggleButton" BasedOn="{StaticResource SaturationToggleStyle}">
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding RightLabel}" Value="">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </ToggleButton.Style>
+                                                    </ToggleButton>
+                                                    <ToggleButton Style="{StaticResource SaturationToggleStyle}"
+                                                                  IsChecked="{Binding IsLeftBlocked}"
+                                                                  ToolTip="BLOCK plein">
+                                                        <ToggleButton.Style>
+                                                            <Style TargetType="ToggleButton" BasedOn="{StaticResource SaturationToggleStyle}">
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding LeftLabel}" Value="">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </ToggleButton.Style>
+                                                    </ToggleButton>
                                                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                                                         <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
                                                                 Click="RenameZone_Click" Tag="{Binding}"/>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -136,30 +136,32 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
-                                    <DockPanel>
-                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                                            <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
-                                                    Click="RenameZone_Click" Tag="{Binding}"/>
-                                            <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
-                                                    Click="RemoveZone_Click" Tag="{Binding}"/>
-                                        </StackPanel>
-                                    </DockPanel>
-                                    <ListBox ItemsSource="{Binding Locomotives}"
-                                             AllowDrop="True"
-                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                             Drop="TrackLocomotives_Drop">
-                                        <ListBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                        Padding="4" Margin="2" CornerRadius="4"
-                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}">
-                                                    <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
-                                                </Border>
-                                            </DataTemplate>
-                                        </ListBox.ItemTemplate>
-                                    </ListBox>
+                                    <StackPanel>
+                                        <DockPanel>
+                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                                                <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
+                                                        Click="RenameZone_Click" Tag="{Binding}"/>
+                                                <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
+                                                        Click="RemoveZone_Click" Tag="{Binding}"/>
+                                            </StackPanel>
+                                        </DockPanel>
+                                        <ListBox ItemsSource="{Binding Locomotives}"
+                                                 AllowDrop="True"
+                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                 Drop="TrackLocomotives_Drop">
+                                            <ListBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}">
+                                                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold"/>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ListBox.ItemTemplate>
+                                        </ListBox>
+                                    </StackPanel>
                                 </Border>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Ploco.Converters"
         xmlns:helpers="clr-namespace:Ploco.Helpers"
-        Title="Ploco - Nouvelle version" Height="800" Width="1200"
+        Title="Ploco - Gestion de parcs locomotives" Height="800" Width="1200"
         Icon="pack://application:,,,/img/train_logo.ico"
         Background="{DynamicResource AppBackgroundBrush}"
         Loaded="Window_Loaded" Closing="Window_Closing">
@@ -706,6 +706,7 @@
             </MenuItem>
             <MenuItem Header="Tapis">
                 <MenuItem Header="T13" Click="MenuItem_TapisT13_Click"/>
+                <MenuItem Header="Actualiser" Click="MenuItem_TapisRefresh_Click"/>
                 <MenuItem Header="37000" IsEnabled="False"/>
             </MenuItem>
             <MenuItem Header="Vue">

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -53,11 +53,6 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
-        <Style x:Key="TileHeaderButton" TargetType="Button">
-            <Setter Property="Margin" Value="4,0,0,0"/>
-            <Setter Property="Padding" Value="4,0"/>
-            <Setter Property="FontSize" Value="11"/>
-        </Style>
         <ContextMenu x:Key="LocomotiveTileContextMenu">
             <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
             <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
@@ -76,9 +71,13 @@
                     MouseMove="Tile_MouseMove"
                     MouseLeftButtonUp="Tile_MouseLeftButtonUp">
                 <StackPanel>
-                    <DockPanel>
-                        <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <Menu DockPanel.Dock="Right">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                        <Menu Grid.Column="1" HorizontalAlignment="Right">
                             <MenuItem Header="...">
                                 <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
                                 <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
@@ -86,7 +85,7 @@
                                 <MenuItem Header="Ajouter voie de sortie" Click="AddDepotOutput_Click" Tag="{Binding}"/>
                             </MenuItem>
                         </Menu>
-                    </DockPanel>
+                    </Grid>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <StackPanel>
                             <TextBlock Text="Locomotives" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
@@ -193,9 +192,13 @@
                     MouseMove="Tile_MouseMove"
                     MouseLeftButtonUp="Tile_MouseLeftButtonUp">
                 <StackPanel>
-                    <DockPanel>
-                        <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <Menu DockPanel.Dock="Right">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                        <Menu Grid.Column="1" HorizontalAlignment="Right">
                             <MenuItem Header="...">
                                 <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
                                 <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
@@ -203,7 +206,7 @@
                                 <MenuItem Header="Ajouter zone" Click="AddGarageZone_Click" Tag="{Binding}"/>
                             </MenuItem>
                         </Menu>
-                    </DockPanel>
+                    </Grid>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <StackPanel>
                             <StackPanel>
@@ -262,50 +265,104 @@
                                     <DataTemplate>
                                         <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
                                             <StackPanel>
-                                                <DockPanel>
-                                                    <TextBlock Text="{Binding LeftLabel}" FontWeight="SemiBold" Foreground="SlateGray">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Visibility" Value="Visible"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                    <DataTrigger Binding="{Binding LeftLabel}" Value="">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="6,0,0,0"/>
-                                                    <TextBlock Text="{Binding RightLabel}" FontWeight="SemiBold" DockPanel.Dock="Right" Foreground="SlateGray">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Setter Property="Visibility" Value="Visible"/>
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                    <DataTrigger Binding="{Binding RightLabel}" Value="">
-                                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                    <ToggleButton Style="{StaticResource RightBlockedToggleStyle}"
-                                                                  DockPanel.Dock="Right"
-                                                                  IsChecked="{Binding IsRightBlocked}"/>
-                                                    <ToggleButton Style="{StaticResource LeftBlockedToggleStyle}"
-                                                                  IsChecked="{Binding IsLeftBlocked}"/>
-                                                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                                                        <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
-                                                                Click="RenameZone_Click" Tag="{Binding}"/>
-                                                        <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
-                                                                Click="RemoveZone_Click" Tag="{Binding}"/>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding LeftLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding LeftLabel}" Value="">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                        <ToggleButton Style="{StaticResource LeftBlockedToggleStyle}"
+                                                                      IsChecked="{Binding IsLeftBlocked}"
+                                                                      Checked="ZoneBlockedToggle_Changed"
+                                                                      Unchecked="ZoneBlockedToggle_Changed"/>
                                                     </StackPanel>
-                                                </DockPanel>
+                                                    <Grid Grid.Column="1">
+                                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                            <StackPanel.Style>
+                                                                <Style TargetType="StackPanel">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </StackPanel.Style>
+                                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="0,0,6,0"/>
+                                                            <Menu VerticalAlignment="Center">
+                                                                <MenuItem Header="...">
+                                                                    <MenuItem Header="Renommer zone" Click="RenameZone_Click" Tag="{Binding}"/>
+                                                                    <MenuItem Header="Supprimer zone" Click="RemoveZone_Click" Tag="{Binding}"/>
+                                                                </MenuItem>
+                                                            </Menu>
+                                                        </StackPanel>
+                                                    </Grid>
+                                                    <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                        <ToggleButton Style="{StaticResource RightBlockedToggleStyle}"
+                                                                      IsChecked="{Binding IsRightBlocked}"
+                                                                      Checked="ZoneBlockedToggle_Changed"
+                                                                      Unchecked="ZoneBlockedToggle_Changed"/>
+                                                        <TextBlock Text="{Binding RightLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding RightLabel}" Value="">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                        <Menu HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                            <Menu.Style>
+                                                                <Style TargetType="Menu">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Menu.Style>
+                                                            <MenuItem Header="...">
+                                                                <MenuItem Header="Renommer zone" Click="RenameZone_Click" Tag="{Binding}"/>
+                                                                <MenuItem Header="Supprimer zone" Click="RemoveZone_Click" Tag="{Binding}"/>
+                                                            </MenuItem>
+                                                        </Menu>
+                                                    </StackPanel>
+                                                </Grid>
                                                 <Grid>
                                                     <ListBox x:Name="GarageZoneList"
                                                              ItemsSource="{Binding Locomotives}"
@@ -362,9 +419,13 @@
                     MouseMove="Tile_MouseMove"
                     MouseLeftButtonUp="Tile_MouseLeftButtonUp">
                 <StackPanel>
-                    <DockPanel>
-                        <TextBlock Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
-                        <Menu DockPanel.Dock="Right">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                        <Menu Grid.Column="1" HorizontalAlignment="Right">
                             <MenuItem Header="...">
                                 <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
                                 <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
@@ -372,18 +433,25 @@
                                 <MenuItem Header="Ajouter voie" Click="AddLineTrack_Click" Tag="{Binding}"/>
                             </MenuItem>
                         </Menu>
-                    </DockPanel>
+                    </Grid>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <ItemsControl ItemsSource="{Binding LineTracks}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
                                     <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
                                         <StackPanel>
-                                            <DockPanel>
-                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                                                <Button DockPanel.Dock="Right" Style="{StaticResource TileHeaderButton}"
-                                                        Content="Supprimer" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
-                                            </DockPanel>
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold"/>
+                                                <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                                    <MenuItem Header="...">
+                                                        <MenuItem Header="Supprimer voie" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
+                                                    </MenuItem>
+                                                </Menu>
+                                            </Grid>
                                             <TextBlock Text="{Binding LineInfo}" FontSize="11" Foreground="SlateGray" Margin="0,2,0,4"/>
                                             <Grid>
                                                 <ListBox x:Name="LineTrackList"

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -18,22 +18,27 @@
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
             <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         </Style>
-        <Style x:Key="SaturationToggleStyle" TargetType="ToggleButton">
-            <Setter Property="Width" Value="12"/>
-            <Setter Property="Height" Value="12"/>
+        <Style x:Key="BlockedSwitchButtonBase" TargetType="Button">
+            <Setter Property="MinWidth" Value="44"/>
+            <Setter Property="Height" Value="20"/>
             <Setter Property="Margin" Value="4,0,0,0"/>
-            <Setter Property="Background" Value="#FFDDDDDD"/>
-            <Setter Property="BorderBrush" Value="#FF888888"/>
+            <Setter Property="Padding" Value="6,0"/>
+            <Setter Property="FontSize" Value="10"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Background" Value="#FF2E7D32"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderBrush" Value="#FF1B5E20"/>
             <Setter Property="BorderThickness" Value="1"/>
-            <Style.Triggers>
-                <Trigger Property="IsChecked" Value="True">
-                    <Setter Property="Background" Value="#FFD32F2F"/>
-                </Trigger>
-            </Style.Triggers>
+            <Setter Property="Content" Value="Free"/>
         </Style>
-        <Style x:Key="LeftBlockedToggleStyle" TargetType="ToggleButton" BasedOn="{StaticResource SaturationToggleStyle}">
-            <Setter Property="ToolTip" Value="BLOCK plein"/>
+        <Style x:Key="LeftBlockedSwitchStyle" TargetType="Button" BasedOn="{StaticResource BlockedSwitchButtonBase}">
+            <Setter Property="ToolTip" Value="BLOCK"/>
             <Style.Triggers>
+                <DataTrigger Binding="{Binding IsLeftBlocked}" Value="True">
+                    <Setter Property="Background" Value="#FFD32F2F"/>
+                    <Setter Property="BorderBrush" Value="#FFB71C1C"/>
+                    <Setter Property="Content" Value="Full"/>
+                </DataTrigger>
                 <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
                     <Setter Property="Visibility" Value="Collapsed"/>
                 </DataTrigger>
@@ -42,9 +47,14 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
-        <Style x:Key="RightBlockedToggleStyle" TargetType="ToggleButton" BasedOn="{StaticResource SaturationToggleStyle}">
-            <Setter Property="ToolTip" Value="BIF plein"/>
+        <Style x:Key="RightBlockedSwitchStyle" TargetType="Button" BasedOn="{StaticResource BlockedSwitchButtonBase}">
+            <Setter Property="ToolTip" Value="BIF"/>
             <Style.Triggers>
+                <DataTrigger Binding="{Binding IsRightBlocked}" Value="True">
+                    <Setter Property="Background" Value="#FFD32F2F"/>
+                    <Setter Property="BorderBrush" Value="#FFB71C1C"/>
+                    <Setter Property="Content" Value="Full"/>
+                </DataTrigger>
                 <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
                     <Setter Property="Visibility" Value="Collapsed"/>
                 </DataTrigger>
@@ -287,10 +297,8 @@
                                                                 </Style>
                                                             </TextBlock.Style>
                                                         </TextBlock>
-                                                        <ToggleButton Style="{StaticResource LeftBlockedToggleStyle}"
-                                                                      IsChecked="{Binding IsLeftBlocked}"
-                                                                      Checked="ZoneBlockedToggle_Changed"
-                                                                      Unchecked="ZoneBlockedToggle_Changed"/>
+                                                        <Button Style="{StaticResource LeftBlockedSwitchStyle}"
+                                                                Click="ToggleLeftBlocked_Click"/>
                                                     </StackPanel>
                                                     <Grid Grid.Column="1">
                                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center">
@@ -326,10 +334,8 @@
                                                         </StackPanel>
                                                     </Grid>
                                                     <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
-                                                        <ToggleButton Style="{StaticResource RightBlockedToggleStyle}"
-                                                                      IsChecked="{Binding IsRightBlocked}"
-                                                                      Checked="ZoneBlockedToggle_Changed"
-                                                                      Unchecked="ZoneBlockedToggle_Changed"/>
+                                                        <Button Style="{StaticResource RightBlockedSwitchStyle}"
+                                                                Click="ToggleRightBlocked_Click"/>
                                                         <TextBlock Text="{Binding RightLabel}" FontWeight="SemiBold" Foreground="SlateGray">
                                                             <TextBlock.Style>
                                                                 <Style TargetType="TextBlock">
@@ -518,6 +524,7 @@
             <MenuItem Header="View">
                 <MenuItem Header="Charger un preset" x:Name="ViewPresetsMenu"/>
                 <MenuItem Header="Enregistrer le preset..." Click="SaveLayoutPreset_Click"/>
+                <MenuItem Header="Supprimer un preset" x:Name="ViewPresetsDeleteMenu"/>
             </MenuItem>
             <MenuItem Header="Option">
                 <MenuItem Header="Reset">

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -1087,11 +1087,6 @@ namespace Ploco
             OpenModelessWindow(() => new TapisT13Window(_locomotives, _tiles));
         }
 
-        private void MenuItem_TapisRefresh_Click(object sender, RoutedEventArgs e)
-        {
-            RefreshTapisT13();
-        }
-
         private void MenuItem_DatabaseManagement_Click(object sender, RoutedEventArgs e)
         {
             OpenModelessWindow(() => new DatabaseManagementWindow(_repository, _locomotives, _tiles));

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -1117,6 +1117,11 @@ namespace Ploco
                 Resources["TrackBorderBrush"] = new SolidColorBrush(Color.FromRgb(80, 80, 80));
                 Resources["ListBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(50, 50, 50));
                 Resources["ListBorderBrush"] = new SolidColorBrush(Color.FromRgb(90, 90, 90));
+                Resources["AppForegroundBrush"] = new SolidColorBrush(Colors.WhiteSmoke);
+                Resources["MenuBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(45, 45, 45));
+                Resources["MenuBorderBrush"] = new SolidColorBrush(Color.FromRgb(70, 70, 70));
+                Resources["ToolBarBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(45, 45, 45));
+                Resources["ToolBarBorderBrush"] = new SolidColorBrush(Color.FromRgb(70, 70, 70));
             }
             else
             {
@@ -1128,6 +1133,11 @@ namespace Ploco
                 Resources["TrackBorderBrush"] = new SolidColorBrush(Color.FromRgb(224, 224, 224));
                 Resources["ListBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(245, 245, 245));
                 Resources["ListBorderBrush"] = new SolidColorBrush(Color.FromRgb(221, 221, 221));
+                Resources["AppForegroundBrush"] = new SolidColorBrush(Color.FromRgb(17, 17, 17));
+                Resources["MenuBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
+                Resources["MenuBorderBrush"] = new SolidColorBrush(Color.FromRgb(221, 221, 221));
+                Resources["ToolBarBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
+                Resources["ToolBarBorderBrush"] = new SolidColorBrush(Color.FromRgb(221, 221, 221));
             }
         }
 

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using Microsoft.Win32;

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -575,7 +575,12 @@ namespace Ploco
             };
             if (dialog.ShowDialog() == true)
             {
-                _repository.ReplaceDatabaseWith(dialog.FileName);
+                if (!_repository.ReplaceDatabaseWith(dialog.FileName))
+                {
+                    MessageBox.Show("Le fichier sélectionné n'est pas une base SQLite valide.", "Chargement", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
                 _repository.Initialize();
                 LoadState();
             }

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -877,16 +877,13 @@ namespace Ploco
 
         private void MarkLocomotiveHs(LocomotiveModel loco)
         {
-            if (loco.Status == LocomotiveStatus.HS)
+            var dialog = new StatusDialog(loco, LocomotiveStatus.HS) { Owner = this };
+            if (dialog.ShowDialog() == true)
             {
-                return;
+                _repository.AddHistory("StatusChanged", $"Statut modifié pour {loco.Number} (HS).");
+                PersistState();
+                RefreshTapisT13();
             }
-
-            loco.Status = LocomotiveStatus.HS;
-            loco.TractionPercent = null;
-            _repository.AddHistory("StatusChanged", $"Statut modifié pour {loco.Number} (HS).");
-            PersistState();
-            RefreshTapisT13();
         }
 
         private void LocomotiveHsCommand_Executed(object sender, ExecutedRoutedEventArgs e)

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -48,7 +48,7 @@ namespace Ploco
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            var result = MessageBox.Show("Are you sure you want to quit?", "Quitter", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            var result = MessageBox.Show("Êtes-vous sûr de vouloir quitter ?", "Quitter", MessageBoxButton.YesNo, MessageBoxImage.Question);
             if (result != MessageBoxResult.Yes)
             {
                 e.Cancel = true;
@@ -789,9 +789,15 @@ namespace Ploco
             dialog.ShowDialog();
         }
 
+        private void MenuItem_TapisT13_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new TapisT13Window(_locomotives, _tiles) { Owner = this };
+            dialog.ShowDialog();
+        }
+
         private void MenuItem_ResetLocomotives_Click(object sender, RoutedEventArgs e)
         {
-            var result = MessageBox.Show("Réinitialiser toutes les locomotives ?", "Reset locomotives", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            var result = MessageBox.Show("Réinitialiser toutes les locomotives ?", "Réinitialisation des locomotives", MessageBoxButton.YesNo, MessageBoxImage.Warning);
             if (result != MessageBoxResult.Yes)
             {
                 return;
@@ -816,7 +822,7 @@ namespace Ploco
 
         private void MenuItem_ResetTiles_Click(object sender, RoutedEventArgs e)
         {
-            var result = MessageBox.Show("Supprimer toutes les tuiles ?", "Reset tuiles", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            var result = MessageBox.Show("Supprimer toutes les tuiles ?", "Réinitialisation des tuiles", MessageBoxButton.YesNo, MessageBoxImage.Warning);
             if (result != MessageBoxResult.Yes)
             {
                 return;

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -812,6 +812,8 @@ namespace Ploco
             {
                 loco.AssignedTrackId = null;
                 loco.Status = LocomotiveStatus.Ok;
+                loco.TractionPercent = null;
+                loco.HsReason = null;
                 loco.Pool = "Lineas";
             }
 

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -1081,6 +1081,11 @@ namespace Ploco
             OpenModelessWindow(() => new TapisT13Window(_locomotives, _tiles));
         }
 
+        private void MenuItem_DatabaseManagement_Click(object sender, RoutedEventArgs e)
+        {
+            OpenModelessWindow(() => new DatabaseManagementWindow(_repository, _locomotives, _tiles));
+        }
+
         private void MenuItem_ResetLocomotives_Click(object sender, RoutedEventArgs e)
         {
             var result = MessageBox.Show("Réinitialiser toutes les locomotives ?", "Réinitialisation des locomotives", MessageBoxButton.YesNo, MessageBoxImage.Warning);

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -500,6 +500,27 @@ namespace Ploco
             }
         }
 
+        private void LocomotiveList_Drop(object sender, DragEventArgs e)
+        {
+            if (!e.Data.GetDataPresent(typeof(LocomotiveModel)))
+            {
+                return;
+            }
+
+            var loco = (LocomotiveModel)e.Data.GetData(typeof(LocomotiveModel))!;
+            var track = _tiles.SelectMany(t => t.Tracks).FirstOrDefault(t => t.Locomotives.Contains(loco));
+            if (track != null)
+            {
+                track.Locomotives.Remove(loco);
+                loco.AssignedTrackId = null;
+                _repository.AddHistory("LocomotiveRemoved", $"Loco {loco.Number} retirée de {track.Name}.");
+            }
+
+            UpdatePoolVisibility();
+            PersistState();
+            e.Handled = true;
+        }
+
         private void TrackLocomotives_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             _dragStartPoint = e.GetPosition(null);

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ namespace Ploco
         private readonly ObservableCollection<TileModel> _tiles = new();
         private readonly List<LayoutPreset> _layoutPresets = new();
         private const string LayoutPresetFileName = "layout_presets.json";
+        private bool _isDarkMode;
         private Point _dragStartPoint;
         private TileModel? _draggedTile;
         private Point _tileDragStart;
@@ -41,6 +42,7 @@ namespace Ploco
             LoadState();
             LoadLayoutPresets();
             RefreshPresetMenu();
+            ApplyTheme(false);
             LocomotiveList.ItemsSource = _locomotives;
             TileCanvas.ItemsSource = _tiles;
             InitializeLocomotiveView();
@@ -869,6 +871,15 @@ namespace Ploco
             PersistState();
         }
 
+        private void ToggleDarkMode_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem)
+            {
+                _isDarkMode = menuItem.IsChecked;
+                ApplyTheme(_isDarkMode);
+            }
+        }
+
         private void SaveLayoutPreset_Click(object sender, RoutedEventArgs e)
         {
             var dialog = new SimpleTextDialog("Enregistrer un preset", "Nom du preset :", "Nouveau preset") { Owner = this };
@@ -1092,6 +1103,32 @@ namespace Ploco
             }
 
             return numbers;
+        }
+
+        private void ApplyTheme(bool darkMode)
+        {
+            if (darkMode)
+            {
+                Resources["AppBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(34, 34, 34));
+                Resources["PanelBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(45, 45, 45));
+                Resources["CanvasBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(40, 40, 40));
+                Resources["TileBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(55, 55, 55));
+                Resources["TileBorderBrush"] = new SolidColorBrush(Color.FromRgb(90, 90, 90));
+                Resources["TrackBorderBrush"] = new SolidColorBrush(Color.FromRgb(80, 80, 80));
+                Resources["ListBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(50, 50, 50));
+                Resources["ListBorderBrush"] = new SolidColorBrush(Color.FromRgb(90, 90, 90));
+            }
+            else
+            {
+                Resources["AppBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
+                Resources["PanelBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(239, 244, 255));
+                Resources["CanvasBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(247, 247, 247));
+                Resources["TileBackgroundBrush"] = new SolidColorBrush(Colors.White);
+                Resources["TileBorderBrush"] = new SolidColorBrush(Color.FromRgb(176, 176, 176));
+                Resources["TrackBorderBrush"] = new SolidColorBrush(Color.FromRgb(224, 224, 224));
+                Resources["ListBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(245, 245, 245));
+                Resources["ListBorderBrush"] = new SolidColorBrush(Color.FromRgb(221, 221, 221));
+            }
         }
 
         private void LoadLayoutPresets()

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -634,6 +634,7 @@ namespace Ploco
             EnsureTrackOffsets(targetTrack);
             _repository.AddHistory("LocomotiveMoved", $"Loco {loco.Number} déplacée vers {targetTrack.Name}.");
             UpdatePoolVisibility();
+            RefreshTapisT13();
         }
 
         private void UpdateLocomotiveDropOffset(LocomotiveModel loco, TrackModel track, ListBox listBox, Point dropPosition)
@@ -730,6 +731,7 @@ namespace Ploco
             {
                 _repository.AddHistory("StatusChanged", $"Statut modifié pour {loco.Number}.");
                 PersistState();
+                RefreshTapisT13();
             }
         }
 
@@ -768,6 +770,7 @@ namespace Ploco
                 _repository.AddHistory("LocomotiveRemoved", $"Loco {loco.Number} retirée de {track.Name}.");
                 UpdatePoolVisibility();
                 PersistState();
+                RefreshTapisT13();
             }
         }
 
@@ -842,6 +845,7 @@ namespace Ploco
                 $"Swap Sibelit {sibelitLoco.Number} ↔ Lineas {lineasLoco.Number}.");
             UpdatePoolVisibility();
             PersistState();
+            RefreshTapisT13();
         }
 
         private static LocomotiveModel? GetLocomotiveFromMenuItem(object sender)
@@ -882,6 +886,7 @@ namespace Ploco
             loco.TractionPercent = null;
             _repository.AddHistory("StatusChanged", $"Statut modifié pour {loco.Number} (HS).");
             PersistState();
+            RefreshTapisT13();
         }
 
         private void LocomotiveHsCommand_Executed(object sender, ExecutedRoutedEventArgs e)
@@ -1067,6 +1072,7 @@ namespace Ploco
             dialog.ShowDialog();
             UpdatePoolVisibility();
             PersistState();
+            RefreshTapisT13();
         }
 
         private void MenuItem_History_Click(object sender, RoutedEventArgs e)
@@ -1079,6 +1085,11 @@ namespace Ploco
         private void MenuItem_TapisT13_Click(object sender, RoutedEventArgs e)
         {
             OpenModelessWindow(() => new TapisT13Window(_locomotives, _tiles));
+        }
+
+        private void MenuItem_TapisRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            RefreshTapisT13();
         }
 
         private void MenuItem_DatabaseManagement_Click(object sender, RoutedEventArgs e)
@@ -1112,6 +1123,7 @@ namespace Ploco
             _repository.AddHistory("ResetLocomotives", "Réinitialisation des locomotives.");
             UpdatePoolVisibility();
             PersistState();
+            RefreshTapisT13();
         }
 
         private void MenuItem_ResetTiles_Click(object sender, RoutedEventArgs e)
@@ -1139,6 +1151,7 @@ namespace Ploco
             _repository.AddHistory("ResetTiles", "Suppression de toutes les tuiles.");
             UpdatePoolVisibility();
             PersistState();
+            RefreshTapisT13();
         }
 
         private void ToggleDarkMode_Click(object sender, RoutedEventArgs e)
@@ -1176,6 +1189,16 @@ namespace Ploco
 
             window.Show();
             window.Activate();
+        }
+
+        private void RefreshTapisT13()
+        {
+            if (_modelessWindows.TryGetValue(typeof(TapisT13Window), out var window)
+                && window is IRefreshableWindow refreshable
+                && window.IsVisible)
+            {
+                refreshable.RefreshData();
+            }
         }
 
         private void LocomotiveItem_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)

--- a/Ploco/Models/AppState.cs
+++ b/Ploco/Models/AppState.cs
@@ -7,7 +7,5 @@ namespace Ploco.Models
         public List<RollingStockSeries> Series { get; set; } = new();
         public List<LocomotiveModel> Locomotives { get; set; } = new();
         public List<TileModel> Tiles { get; set; } = new();
-        public string ActivePoolName { get; set; } = "Lineas";
-        public bool HideNonActivePool { get; set; }
     }
 }

--- a/Ploco/Models/AppState.cs
+++ b/Ploco/Models/AppState.cs
@@ -7,5 +7,7 @@ namespace Ploco.Models
         public List<RollingStockSeries> Series { get; set; } = new();
         public List<LocomotiveModel> Locomotives { get; set; } = new();
         public List<TileModel> Tiles { get; set; } = new();
+        public string ActivePoolName { get; set; } = "Lineas";
+        public bool HideNonActivePool { get; set; }
     }
 }

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -42,6 +42,7 @@ namespace Ploco.Models
         private LocomotiveStatus _status;
         private int? _tractionPercent;
         private string? _hsReason;
+        private double? _assignedTrackOffsetX;
         private int? _assignedTrackId;
         private bool _isVisibleInActivePool = true;
 
@@ -112,6 +113,19 @@ namespace Ploco.Models
                 if (_assignedTrackId != value)
                 {
                     _assignedTrackId = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public double? AssignedTrackOffsetX
+        {
+            get => _assignedTrackOffsetX;
+            set
+            {
+                if (_assignedTrackOffsetX != value)
+                {
+                    _assignedTrackOffsetX = value;
                     OnPropertyChanged();
                 }
             }
@@ -349,6 +363,8 @@ namespace Ploco.Models
         private string _name = string.Empty;
         private double _x;
         private double _y;
+        private double _width = 360;
+        private double _height = 220;
         private readonly ObservableCollection<TrackModel> _outputTracks = new();
         private readonly ObservableCollection<TrackModel> _zoneTracks = new();
         private readonly ObservableCollection<TrackModel> _lineTracks = new();
@@ -408,6 +424,32 @@ namespace Ploco.Models
                 if (_y != value)
                 {
                     _y = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public double Width
+        {
+            get => _width;
+            set
+            {
+                if (Math.Abs(_width - value) > 0.1)
+                {
+                    _width = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public double Height
+        {
+            get => _height;
+            set
+            {
+                if (Math.Abs(_height - value) > 0.1)
+                {
+                    _height = value;
                     OnPropertyChanged();
                 }
             }

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -29,8 +30,10 @@ namespace Ploco.Models
 
     public class LocomotiveModel : INotifyPropertyChanged
     {
+        private string _pool = "Lineas";
         private LocomotiveStatus _status;
         private int? _assignedTrackId;
+        private bool _isVisibleInActivePool = true;
 
         public int Id { get; set; }
         public int SeriesId { get; set; }
@@ -50,6 +53,19 @@ namespace Ploco.Models
             }
         }
 
+        public string Pool
+        {
+            get => _pool;
+            set
+            {
+                if (_pool != value)
+                {
+                    _pool = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         public int? AssignedTrackId
         {
             get => _assignedTrackId;
@@ -63,7 +79,20 @@ namespace Ploco.Models
             }
         }
 
-        public string DisplayName => $"{SeriesName}-{Number}";
+        public bool IsVisibleInActivePool
+        {
+            get => _isVisibleInActivePool;
+            set
+            {
+                if (_isVisibleInActivePool != value)
+                {
+                    _isVisibleInActivePool = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string DisplayName => Number.ToString();
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -71,6 +100,13 @@ namespace Ploco.Models
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+    }
+
+    public class HistoryEntry
+    {
+        public DateTime Timestamp { get; set; }
+        public string Action { get; set; } = string.Empty;
+        public string Details { get; set; } = string.Empty;
     }
 
     public class TrackModel : INotifyPropertyChanged

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -9,8 +9,7 @@ namespace Ploco.Models
     public enum LocomotiveStatus
     {
         Ok,
-        DefautMineur,
-        AControler,
+        ManqueTraction,
         HS
     }
 
@@ -41,6 +40,8 @@ namespace Ploco.Models
     {
         private string _pool = "Lineas";
         private LocomotiveStatus _status;
+        private int? _tractionPercent;
+        private string? _hsReason;
         private int? _assignedTrackId;
         private bool _isVisibleInActivePool = true;
 
@@ -57,6 +58,34 @@ namespace Ploco.Models
                 if (_status != value)
                 {
                     _status = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(TractionDisplay));
+                }
+            }
+        }
+
+        public int? TractionPercent
+        {
+            get => _tractionPercent;
+            set
+            {
+                if (_tractionPercent != value)
+                {
+                    _tractionPercent = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(TractionDisplay));
+                }
+            }
+        }
+
+        public string? HsReason
+        {
+            get => _hsReason;
+            set
+            {
+                if (_hsReason != value)
+                {
+                    _hsReason = value;
                     OnPropertyChanged();
                 }
             }
@@ -102,6 +131,9 @@ namespace Ploco.Models
         }
 
         public string DisplayName => Number.ToString();
+        public string TractionDisplay => Status == LocomotiveStatus.ManqueTraction && TractionPercent.HasValue
+            ? $"{TractionPercent.Value}%"
+            : string.Empty;
 
         public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -126,6 +126,8 @@ namespace Ploco.Models
         private string? _stopTime;
         private string? _issueReason;
         private bool _isLocomotiveHs;
+        private string? _leftLabel;
+        private string? _rightLabel;
 
         public int Id { get; set; }
         public int TileId { get; set; }
@@ -209,6 +211,32 @@ namespace Ploco.Models
                     _isLocomotiveHs = value;
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(LineInfo));
+                }
+            }
+        }
+
+        public string? LeftLabel
+        {
+            get => _leftLabel;
+            set
+            {
+                if (_leftLabel != value)
+                {
+                    _leftLabel = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string? RightLabel
+        {
+            get => _rightLabel;
+            set
+            {
+                if (_rightLabel != value)
+                {
+                    _rightLabel = value;
+                    OnPropertyChanged();
                 }
             }
         }

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -288,13 +288,14 @@ namespace Ploco.Models
         {
             get
             {
-                if (!IsOnTrain)
-                {
-                    return "Locomotive isolée";
-                }
-
                 var status = IsLocomotiveHs ? "HS" : "OK";
                 var reason = string.IsNullOrWhiteSpace(IssueReason) ? "Raison non précisée" : IssueReason;
+
+                if (!IsOnTrain)
+                {
+                    return $"Locomotive isolée · {reason} · Loco {status}";
+                }
+
                 var time = string.IsNullOrWhiteSpace(StopTime) ? "Heure inconnue" : StopTime;
                 var train = string.IsNullOrWhiteSpace(TrainNumber) ? "Train non précisé" : $"Train {TrainNumber}";
                 return $"{train} · Arrêt {time} · {reason} · Loco {status}";

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -128,6 +128,8 @@ namespace Ploco.Models
         private bool _isLocomotiveHs;
         private string? _leftLabel;
         private string? _rightLabel;
+        private bool _isLeftBlocked;
+        private bool _isRightBlocked;
 
         public int Id { get; set; }
         public int TileId { get; set; }
@@ -236,6 +238,32 @@ namespace Ploco.Models
                 if (_rightLabel != value)
                 {
                     _rightLabel = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsLeftBlocked
+        {
+            get => _isLeftBlocked;
+            set
+            {
+                if (_isLeftBlocked != value)
+                {
+                    _isLeftBlocked = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsRightBlocked
+        {
+            get => _isRightBlocked;
+            set
+            {
+                if (_isRightBlocked != value)
+                {
+                    _isRightBlocked = value;
                     OnPropertyChanged();
                 }
             }

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -130,6 +130,7 @@ namespace Ploco.Models
         private string? _rightLabel;
         private bool _isLeftBlocked;
         private bool _isRightBlocked;
+        private string? _trainNumber;
 
         public int Id { get; set; }
         public int TileId { get; set; }
@@ -269,6 +270,20 @@ namespace Ploco.Models
             }
         }
 
+        public string? TrainNumber
+        {
+            get => _trainNumber;
+            set
+            {
+                if (_trainNumber != value)
+                {
+                    _trainNumber = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(LineInfo));
+                }
+            }
+        }
+
         public string LineInfo
         {
             get
@@ -281,7 +296,8 @@ namespace Ploco.Models
                 var status = IsLocomotiveHs ? "HS" : "OK";
                 var reason = string.IsNullOrWhiteSpace(IssueReason) ? "Raison non précisée" : IssueReason;
                 var time = string.IsNullOrWhiteSpace(StopTime) ? "Heure inconnue" : StopTime;
-                return $"Train arrêté à {time} · {reason} · Loco {status}";
+                var train = string.IsNullOrWhiteSpace(TrainNumber) ? "Train non précisé" : $"Train {TrainNumber}";
+                return $"{train} · Arrêt {time} · {reason} · Loco {status}";
             }
         }
 

--- a/Ploco/Models/locot13.cs
+++ b/Ploco/Models/locot13.cs
@@ -15,11 +15,11 @@ namespace Ploco.Models
     {
         private bool _isOnCanvas;
         private StatutLocomotive _statut;
-        private string _currentPool;             // Propriété ajoutée pour le pool actuel
-        private string _defautMoteurDetails;
-        private string _emDetails;
-        private string _atevapDetails;
-        private string _modificationNotes;
+        private string _currentPool = string.Empty;             // Propriété ajoutée pour le pool actuel
+        private string _defautMoteurDetails = string.Empty;
+        private string _emDetails = string.Empty;
+        private string _atevapDetails = string.Empty;
+        private string _modificationNotes = string.Empty;
         private DateTime? _lastModificationDate;
 
         public int NumeroSerie { get; set; }

--- a/Ploco/ModifierStatutDialog.xaml.cs
+++ b/Ploco/ModifierStatutDialog.xaml.cs
@@ -51,9 +51,8 @@ namespace Ploco
         private void btnValider_Click(object sender, RoutedEventArgs e)
         {
             // Récupérer le nouveau statut depuis le ComboBox.
-            if (cbStatut.SelectedItem is ComboBoxItem selectedItem && selectedItem.Tag != null)
+            if (cbStatut.SelectedItem is ComboBoxItem selectedItem && selectedItem.Tag is string statutString && !string.IsNullOrWhiteSpace(statutString))
             {
-                string statutString = selectedItem.Tag.ToString();
                 if (Enum.TryParse(statutString, out StatutLocomotive statut))
                 {
                     NewStatut = statut;

--- a/Ploco/ParcLocoWindow.xaml
+++ b/Ploco/ParcLocoWindow.xaml
@@ -39,7 +39,7 @@
                         <Border Width="40" Height="30" Margin="5"
                                 Background="{Binding Statut, Converter={StaticResource StatutToBrushConverter}}"
                                 ContextMenu="{StaticResource LocomotivesContextMenu}">
-                            <TextBlock Text="{Binding NumeroSerie}" 
+                            <TextBlock Text="{Binding Number}" 
                                        Foreground="White" 
                                        VerticalAlignment="Center" 
                                        HorizontalAlignment="Center" 
@@ -63,7 +63,7 @@
                         <Border Width="40" Height="30" Margin="5"
                                 Background="{Binding Statut, Converter={StaticResource StatutToBrushConverter}}"
                                 ContextMenu="{StaticResource LocomotivesContextMenu}">
-                            <TextBlock Text="{Binding NumeroSerie}" 
+                            <TextBlock Text="{Binding Number}" 
                                        Foreground="White" 
                                        VerticalAlignment="Center" 
                                        HorizontalAlignment="Center" 

--- a/Ploco/ParcLocoWindow.xaml.cs
+++ b/Ploco/ParcLocoWindow.xaml.cs
@@ -9,10 +9,10 @@ namespace Ploco
 {
     public partial class ParcLocoWindow : Window
     {
-        public ObservableCollection<Locomotive> SibelitPool { get; set; }
-        public ObservableCollection<Locomotive> LineasPool { get; set; }
+        public ObservableCollection<LocomotiveModel> SibelitPool { get; set; }
+        public ObservableCollection<LocomotiveModel> LineasPool { get; set; }
 
-        public ParcLocoWindow(ObservableCollection<Locomotive> sibelitPool, ObservableCollection<Locomotive> lineasPool)
+        public ParcLocoWindow(ObservableCollection<LocomotiveModel> sibelitPool, ObservableCollection<LocomotiveModel> lineasPool)
         {
             InitializeComponent();
             Owner = Application.Current.MainWindow; // Définit la fenêtre principale comme propriétaire
@@ -23,9 +23,9 @@ namespace Ploco
             ItemsControlLineas.ItemsSource = LineasPool;
 
             CollectionView viewSibelit = (CollectionView)CollectionViewSource.GetDefaultView(SibelitPool);
-            viewSibelit.SortDescriptions.Add(new SortDescription("NumeroSerie", ListSortDirection.Ascending));
+            viewSibelit.SortDescriptions.Add(new SortDescription(nameof(LocomotiveModel.Number), ListSortDirection.Ascending));
             CollectionView viewLineas = (CollectionView)CollectionViewSource.GetDefaultView(LineasPool);
-            viewLineas.SortDescriptions.Add(new SortDescription("NumeroSerie", ListSortDirection.Ascending));
+            viewLineas.SortDescriptions.Add(new SortDescription(nameof(LocomotiveModel.Number), ListSortDirection.Ascending));
         }
 
         private void MenuItem_Swap_Click(object sender, RoutedEventArgs e)

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -18,8 +18,14 @@
         </Grid.RowDefinitions>
 
         <!-- Titres -->
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="Pool Sibelit" FontWeight="Bold" Margin="0,0,0,10"/>
-        <TextBlock Grid.Column="2" Grid.Row="0" Text="Pool Lineas" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Right"/>
+        <StackPanel Grid.Column="0" Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock Text="Pool Sibelit" FontWeight="Bold"/>
+            <TextBlock x:Name="SibelitCountText" Foreground="SlateGray"/>
+        </StackPanel>
+        <StackPanel Grid.Column="2" Grid.Row="0" Margin="0,0,0,10" HorizontalAlignment="Right">
+            <TextBlock Text="Pool Lineas" FontWeight="Bold" HorizontalAlignment="Right"/>
+            <TextBlock x:Name="LineasCountText" Foreground="SlateGray" HorizontalAlignment="Right"/>
+        </StackPanel>
 
         <!-- ListBox pour Pool Sibelit -->
         <ListBox x:Name="ListBoxSibelit"

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -13,30 +13,16 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBlock Text="Parc actif :" VerticalAlignment="Center" Margin="0,0,6,0"/>
-            <ComboBox x:Name="ActivePoolCombo" Width="120" SelectionChanged="ActivePoolCombo_SelectionChanged">
-                <ComboBoxItem Content="Lineas"/>
-                <ComboBoxItem Content="Sibelit"/>
-            </ComboBox>
-            <CheckBox x:Name="HideNonActiveCheckBox" Margin="12,0,0,0"
-                      Content="Masquer les locomotives hors parc actif"
-                      VerticalAlignment="Center"
-                      Checked="HideNonActiveCheckBox_Checked"
-                      Unchecked="HideNonActiveCheckBox_Checked"/>
-        </StackPanel>
-
         <!-- Titres -->
-        <TextBlock Grid.Column="0" Grid.Row="1" Text="Pool Sibelit" FontWeight="Bold" Margin="0,0,0,10"/>
-        <TextBlock Grid.Column="2" Grid.Row="1" Text="Pool Lineas" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Right"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" Text="Pool Sibelit" FontWeight="Bold" Margin="0,0,0,10"/>
+        <TextBlock Grid.Column="2" Grid.Row="0" Text="Pool Lineas" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Right"/>
 
         <!-- ListBox pour Pool Sibelit -->
-        <ListBox x:Name="ListBoxSibelit" Grid.Column="0" Grid.Row="1" Margin="0,30,5,0" SelectionMode="Extended">
+        <ListBox x:Name="ListBoxSibelit" Grid.Column="0" Grid.Row="0" Margin="0,30,5,0" SelectionMode="Extended">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
@@ -47,7 +33,7 @@
             </ListBox.ItemTemplate>
         </ListBox>
         <!-- ListBox pour Pool Lineas -->
-        <ListBox x:Name="ListBoxLineas" Grid.Column="2" Grid.Row="1" Margin="5,30,0,0" SelectionMode="Extended">
+        <ListBox x:Name="ListBoxLineas" Grid.Column="2" Grid.Row="0" Margin="5,30,0,0" SelectionMode="Extended">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
@@ -59,12 +45,12 @@
         </ListBox>
 
         <!-- Boutons de transfert -->
-        <StackPanel Grid.Column="1" Grid.Row="1" VerticalAlignment="Center">
+        <StackPanel Grid.Column="1" Grid.Row="0" VerticalAlignment="Center">
             <Button x:Name="BtnTransferToLineas" Content="&gt;&gt;" Width="50" Margin="0,5" Click="BtnTransferToLineas_Click"/>
             <Button x:Name="BtnTransferToSibelit" Content="&lt;&lt;" Width="50" Margin="0,5" Click="BtnTransferToSibelit_Click"/>
         </StackPanel>
 
         <!-- Bouton de fermeture -->
-        <Button Grid.Column="2" Grid.Row="2" Content="Fermer" Width="100" HorizontalAlignment="Right" Margin="0,10,0,0" Click="BtnClose_Click"/>
+        <Button Grid.Column="2" Grid.Row="1" Content="Fermer" Width="100" HorizontalAlignment="Right" Margin="0,10,0,0" Click="BtnClose_Click"/>
     </Grid>
 </Window>

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -53,7 +53,7 @@
                             <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
                                        HorizontalAlignment="Left"/>
                             <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                       HorizontalAlignment="Right">
+                                       HorizontalAlignment="Right" Margin="0,2,0,0">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Visibility" Value="Visible"/>
@@ -96,7 +96,7 @@
                             <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
                                        HorizontalAlignment="Left"/>
                             <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                       HorizontalAlignment="Right">
+                                       HorizontalAlignment="Right" Margin="0,2,0,0">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Visibility" Value="Visible"/>

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -22,7 +22,14 @@
         <TextBlock Grid.Column="2" Grid.Row="0" Text="Pool Lineas" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Right"/>
 
         <!-- ListBox pour Pool Sibelit -->
-        <ListBox x:Name="ListBoxSibelit" Grid.Column="0" Grid.Row="0" Margin="0,30,5,0" SelectionMode="Extended">
+        <ListBox x:Name="ListBoxSibelit"
+                 Grid.Column="0"
+                 Grid.Row="0"
+                 Margin="0,30,5,0"
+                 SelectionMode="Extended"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 ScrollViewer.CanContentScroll="False">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel/>
@@ -38,7 +45,14 @@
             </ListBox.ItemTemplate>
         </ListBox>
         <!-- ListBox pour Pool Lineas -->
-        <ListBox x:Name="ListBoxLineas" Grid.Column="2" Grid.Row="0" Margin="5,30,0,0" SelectionMode="Extended">
+        <ListBox x:Name="ListBoxLineas"
+                 Grid.Column="2"
+                 Grid.Row="0"
+                 Margin="5,30,0,0"
+                 SelectionMode="Extended"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 ScrollViewer.CanContentScroll="False">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel/>

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -45,7 +45,23 @@
                 <DataTemplate>
                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                             CornerRadius="4" Padding="4" Margin="2">
-                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                        <Grid>
+                            <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                       HorizontalAlignment="Left" VerticalAlignment="Top"/>
+                            <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                       HorizontalAlignment="Right" VerticalAlignment="Top">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
                     </Border>
                 </DataTemplate>
             </ListBox.ItemTemplate>
@@ -68,7 +84,23 @@
                 <DataTemplate>
                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                             CornerRadius="4" Padding="4" Margin="2">
-                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                        <Grid>
+                            <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                       HorizontalAlignment="Left" VerticalAlignment="Top"/>
+                            <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                       HorizontalAlignment="Right" VerticalAlignment="Top">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
                     </Border>
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -1,7 +1,11 @@
 ﻿<Window x:Class="Ploco.PoolTransferWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Ploco.Converters"
         Title="Gérer les Locomotives" Height="400" Width="600">
+    <Window.Resources>
+        <local:StatutToBrushConverter x:Key="StatutToBrushConverter"/>
+    </Window.Resources>
     <Grid Margin="10">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
@@ -9,26 +13,58 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
+        <StackPanel Grid.Row="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="Parc actif :" VerticalAlignment="Center" Margin="0,0,6,0"/>
+            <ComboBox x:Name="ActivePoolCombo" Width="120" SelectionChanged="ActivePoolCombo_SelectionChanged">
+                <ComboBoxItem Content="Lineas"/>
+                <ComboBoxItem Content="Sibelit"/>
+            </ComboBox>
+            <CheckBox x:Name="HideNonActiveCheckBox" Margin="12,0,0,0"
+                      Content="Masquer les locomotives hors parc actif"
+                      VerticalAlignment="Center"
+                      Checked="HideNonActiveCheckBox_Checked"
+                      Unchecked="HideNonActiveCheckBox_Checked"/>
+        </StackPanel>
+
         <!-- Titres -->
-        <TextBlock Grid.Column="0" Text="Pool Sibelit" FontWeight="Bold" Margin="0,0,0,10"/>
-        <TextBlock Grid.Column="2" Text="Pool Lineas" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Right"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" Text="Pool Sibelit" FontWeight="Bold" Margin="0,0,0,10"/>
+        <TextBlock Grid.Column="2" Grid.Row="1" Text="Pool Lineas" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Right"/>
 
         <!-- ListBox pour Pool Sibelit -->
-        <ListBox x:Name="ListBoxSibelit" Grid.Column="0" Grid.Row="0" Margin="0,30,5,0" SelectionMode="Extended"/>
+        <ListBox x:Name="ListBoxSibelit" Grid.Column="0" Grid.Row="1" Margin="0,30,5,0" SelectionMode="Extended">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                            CornerRadius="4" Padding="4" Margin="2">
+                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                    </Border>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
         <!-- ListBox pour Pool Lineas -->
-        <ListBox x:Name="ListBoxLineas" Grid.Column="2" Grid.Row="0" Margin="5,30,0,0" SelectionMode="Extended"/>
+        <ListBox x:Name="ListBoxLineas" Grid.Column="2" Grid.Row="1" Margin="5,30,0,0" SelectionMode="Extended">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                            CornerRadius="4" Padding="4" Margin="2">
+                        <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                    </Border>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
 
         <!-- Boutons de transfert -->
-        <StackPanel Grid.Column="1" Grid.Row="0" VerticalAlignment="Center">
+        <StackPanel Grid.Column="1" Grid.Row="1" VerticalAlignment="Center">
             <Button x:Name="BtnTransferToLineas" Content="&gt;&gt;" Width="50" Margin="0,5" Click="BtnTransferToLineas_Click"/>
             <Button x:Name="BtnTransferToSibelit" Content="&lt;&lt;" Width="50" Margin="0,5" Click="BtnTransferToSibelit_Click"/>
         </StackPanel>
 
         <!-- Bouton de fermeture -->
-        <Button Grid.Column="2" Grid.Row="1" Content="Fermer" Width="100" HorizontalAlignment="Right" Margin="0,10,0,0" Click="BtnClose_Click"/>
+        <Button Grid.Column="2" Grid.Row="2" Content="Fermer" Width="100" HorizontalAlignment="Right" Margin="0,10,0,0" Click="BtnClose_Click"/>
     </Grid>
 </Window>

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -46,10 +46,14 @@
                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                             CornerRadius="4" Padding="4" Margin="2">
                         <Grid>
-                            <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                       HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                            <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                       HorizontalAlignment="Right" VerticalAlignment="Top">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                       HorizontalAlignment="Left"/>
+                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                       HorizontalAlignment="Right">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Visibility" Value="Visible"/>
@@ -85,10 +89,14 @@
                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
                             CornerRadius="4" Padding="4" Margin="2">
                         <Grid>
-                            <TextBlock Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
-                                       HorizontalAlignment="Left" VerticalAlignment="Top"/>
-                            <TextBlock Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
-                                       HorizontalAlignment="Right" VerticalAlignment="Top">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                       HorizontalAlignment="Left"/>
+                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                       HorizontalAlignment="Right">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Visibility" Value="Visible"/>

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -23,6 +23,11 @@
 
         <!-- ListBox pour Pool Sibelit -->
         <ListBox x:Name="ListBoxSibelit" Grid.Column="0" Grid.Row="0" Margin="0,30,5,0" SelectionMode="Extended">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel/>
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
@@ -34,6 +39,11 @@
         </ListBox>
         <!-- ListBox pour Pool Lineas -->
         <ListBox x:Name="ListBoxLineas" Grid.Column="2" Grid.Row="0" Margin="5,30,0,0" SelectionMode="Extended">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel/>
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"

--- a/Ploco/PoolTransferWindow.xaml.cs
+++ b/Ploco/PoolTransferWindow.xaml.cs
@@ -13,18 +13,13 @@ namespace Ploco
         private readonly CollectionViewSource _lineasSource;
         private readonly CollectionViewSource _sibelitSource;
 
-        public string ActivePool { get; private set; }
-        public bool HideNonActivePool { get; private set; }
-
-        public PoolTransferWindow(ObservableCollection<LocomotiveModel> locomotives, string activePool, bool hideNonActivePool)
+        public PoolTransferWindow(ObservableCollection<LocomotiveModel> locomotives)
         {
             InitializeComponent();
             Owner = Application.Current.MainWindow; // Définit la fenêtre principale comme propriétaire
             WindowStartupLocation = WindowStartupLocation.CenterOwner; // Centre la fenêtre sur la principale
 
             _locomotives = locomotives;
-            ActivePool = activePool;
-            HideNonActivePool = hideNonActivePool;
 
             _lineasSource = new CollectionViewSource { Source = _locomotives };
             _lineasSource.SortDescriptions.Add(new SortDescription(nameof(LocomotiveModel.Number), ListSortDirection.Ascending));
@@ -48,9 +43,6 @@ namespace Ploco
 
             ListBoxLineas.ItemsSource = _lineasSource.View;
             ListBoxSibelit.ItemsSource = _sibelitSource.View;
-
-            ActivePoolCombo.SelectedIndex = string.Equals(ActivePool, "Sibelit") ? 1 : 0;
-            HideNonActiveCheckBox.IsChecked = HideNonActivePool;
         }
 
         private void BtnTransferToLineas_Click(object sender, RoutedEventArgs e)
@@ -86,17 +78,5 @@ namespace Ploco
             _sibelitSource.View.Refresh();
         }
 
-        private void ActivePoolCombo_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
-        {
-            if (ActivePoolCombo.SelectedItem is System.Windows.Controls.ComboBoxItem item && item.Content is string poolName)
-            {
-                ActivePool = poolName;
-            }
-        }
-
-        private void HideNonActiveCheckBox_Checked(object sender, RoutedEventArgs e)
-        {
-            HideNonActivePool = HideNonActiveCheckBox.IsChecked == true;
-        }
     }
 }

--- a/Ploco/PoolTransferWindow.xaml.cs
+++ b/Ploco/PoolTransferWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace Ploco
 
             ListBoxLineas.ItemsSource = _lineasSource.View;
             ListBoxSibelit.ItemsSource = _sibelitSource.View;
+            UpdateCounts();
         }
 
         private void BtnTransferToLineas_Click(object sender, RoutedEventArgs e)
@@ -76,7 +77,15 @@ namespace Ploco
         {
             _lineasSource.View.Refresh();
             _sibelitSource.View.Refresh();
+            UpdateCounts();
         }
 
+        private void UpdateCounts()
+        {
+            var sibelitCount = _locomotives.Count(loco => string.Equals(loco.Pool, "Sibelit", System.StringComparison.OrdinalIgnoreCase));
+            var lineasCount = _locomotives.Count(loco => string.Equals(loco.Pool, "Lineas", System.StringComparison.OrdinalIgnoreCase));
+            SibelitCountText.Text = $"Nombre de locomotives : {sibelitCount}";
+            LineasCountText.Text = $"Nombre de locomotives : {lineasCount}";
+        }
     }
 }

--- a/Ploco/SwapDialog.xaml.cs
+++ b/Ploco/SwapDialog.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Windows;
 using System.Windows.Data;
 using System.Linq;
@@ -10,11 +9,11 @@ namespace Ploco
 {
     public partial class SwapDialog : Window
     {
-        public Locomotive LocoFromSibelit { get; set; }
-        public ObservableCollection<Locomotive> LineasPool { get; set; }
-        public Locomotive SelectedLoco { get; set; }  // La loco sélectionnée dans le ComboBox
+        public LocomotiveModel LocoFromSibelit { get; }
+        public ObservableCollection<LocomotiveModel> LineasPool { get; }
+        public LocomotiveModel? SelectedLoco { get; private set; }
 
-        public SwapDialog(Locomotive locoFromSibelit, ObservableCollection<Locomotive> lineasPool)
+        public SwapDialog(LocomotiveModel locoFromSibelit, ObservableCollection<LocomotiveModel> lineasPool)
         {
             InitializeComponent();
             Owner = Application.Current.MainWindow; // Définit la fenêtre principale comme propriétaire
@@ -24,12 +23,13 @@ namespace Ploco
             LineasPool = lineasPool;
 
             // Afficher la loco de Sibelit dans un TextBlock pour information
-            tbLocoSibelit.Text = LocoFromSibelit.ToString();
+            tbLocoSibelit.Text = LocoFromSibelit.Number.ToString();
 
             // Remplir le ComboBox avec la pool Lineas et trier par NumeroSerie
             cbLineas.ItemsSource = LineasPool;
             CollectionView view = (CollectionView)CollectionViewSource.GetDefaultView(LineasPool);
-            view.SortDescriptions.Add(new SortDescription("NumeroSerie", ListSortDirection.Ascending));
+            view.SortDescriptions.Add(new System.ComponentModel.SortDescription(nameof(LocomotiveModel.Number), System.ComponentModel.ListSortDirection.Ascending));
+            cbLineas.DisplayMemberPath = nameof(LocomotiveModel.DisplayName);
 
             if (cbLineas.Items.Count > 0)
                 cbLineas.SelectedIndex = 0;
@@ -47,18 +47,7 @@ namespace Ploco
             }
 
             // La loco sélectionnée dans la pool Lineas est celle avec laquelle on souhaite effectuer le swap
-            SelectedLoco = cbLineas.SelectedItem as Locomotive;
-
-            // Archive les informations du swap dans un fichier log
-            string logEntry = $"Action: Swap, Loc Sibelit: {LocoFromSibelit}, Loc Lineas: {SelectedLoco}, Date: {tbDateTime.Text}, Message: {tbMessage.Text}";
-            try
-            {
-                System.IO.File.AppendAllText("SwapLog.txt", logEntry + Environment.NewLine);
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("Erreur lors de l'enregistrement du swap : " + ex.Message);
-            }
+            SelectedLoco = cbLineas.SelectedItem as LocomotiveModel;
 
             // Le swap effectif (mise à jour des pools et de CurrentPool) se fera dans le code appelant
             this.DialogResult = true;


### PR DESCRIPTION
### Motivation
- Address build errors caused by using a non-existent `SqliteConnection.LastInsertRowId` property by switching to a compatible retrieval method for the last inserted row id.

### Description
- Replaced direct uses of `connection.LastInsertRowId` with a new helper `GetLastInsertRowId(SqliteConnection)` that executes `SELECT last_insert_rowid();` in `Ploco/Data/PlocoRepository.cs` and reused it for series, locomotive, tile, and track insertions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2e45bb48833189cbd3223905debb)