### PR TITLE
Résolution de conflits modèles et ajout du support Lignes de roulement + persistance/UI

### DIFF
--- a/Ploco/Converters/StatutToBrushConverter.cs
+++ b/Ploco/Converters/StatutToBrushConverter.cs
@@ -15,8 +15,7 @@ namespace Ploco.Converters
                 return statut switch
                 {
                     LocomotiveStatus.Ok => Brushes.Green,
-                    LocomotiveStatus.DefautMineur => Brushes.Gold,
-                    LocomotiveStatus.AControler => Brushes.Orange,
+                    LocomotiveStatus.ManqueTraction => Brushes.Orange,
                     LocomotiveStatus.HS => Brushes.Red,
                     _ => Brushes.Gray,
                 };

--- a/Ploco/Dialogs/DatabaseManagementWindow.xaml
+++ b/Ploco/Dialogs/DatabaseManagementWindow.xaml
@@ -1,0 +1,56 @@
+<Window x:Class="Ploco.Dialogs.DatabaseManagementWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Gestion base de données" Height="600" Width="900"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Visualisation en lecture seule des données et nettoyage des éléments non essentiels."
+                   FontWeight="SemiBold" Margin="0,0,0,8"/>
+
+        <TabControl Grid.Row="1">
+            <TabItem Header="Résumé">
+                <DataGrid x:Name="SummaryGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserAddRows="False" CanUserDeleteRows="False" HeadersVisibility="Column">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Table" Binding="{Binding Name}" Width="*"/>
+                        <DataGridTextColumn Header="Enregistrements" Binding="{Binding Count}" Width="Auto"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+            <TabItem Header="Historique">
+                <DataGrid x:Name="HistoryGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserAddRows="False" CanUserDeleteRows="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Date" Binding="{Binding Timestamp}" Width="180"/>
+                        <DataGridTextColumn Header="Action" Binding="{Binding Action}" Width="160"/>
+                        <DataGridTextColumn Header="Détails" Binding="{Binding Details}" Width="*"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+            <TabItem Header="États locomotives">
+                <DataGrid x:Name="LocomotiveGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserAddRows="False" CanUserDeleteRows="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Numéro" Binding="{Binding Number}" Width="100"/>
+                        <DataGridTextColumn Header="Pool" Binding="{Binding Pool}" Width="120"/>
+                        <DataGridTextColumn Header="Statut" Binding="{Binding Status}" Width="120"/>
+                        <DataGridTextColumn Header="Traction %" Binding="{Binding TractionPercent}" Width="120"/>
+                        <DataGridTextColumn Header="Raison HS" Binding="{Binding HsReason}" Width="*"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+        </TabControl>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Vider l'historique" Width="160" Margin="0,0,8,0" Click="ClearHistory_Click"/>
+            <Button Content="Vider les données temporaires" Width="200" Margin="0,0,8,0" Click="ClearTempData_Click"/>
+            <Button Content="Réinitialiser les données d'état" Width="220" Click="ResetOperationalState_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/DatabaseManagementWindow.xaml.cs
+++ b/Ploco/Dialogs/DatabaseManagementWindow.xaml.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using Ploco.Data;
+using Ploco.Helpers;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class DatabaseManagementWindow : Window, IRefreshableWindow
+    {
+        private readonly PlocoRepository _repository;
+        private readonly IEnumerable<LocomotiveModel> _locomotives;
+        private readonly IEnumerable<TileModel> _tiles;
+        private readonly ObservableCollection<TableSummary> _summaries = new();
+        private readonly ObservableCollection<HistoryEntry> _history = new();
+        private readonly ObservableCollection<LocomotiveStateRow> _locomotiveStates = new();
+
+        public DatabaseManagementWindow(PlocoRepository repository, IEnumerable<LocomotiveModel> locomotives, IEnumerable<TileModel> tiles)
+        {
+            InitializeComponent();
+            _repository = repository;
+            _locomotives = locomotives;
+            _tiles = tiles;
+            SummaryGrid.ItemsSource = _summaries;
+            HistoryGrid.ItemsSource = _history;
+            LocomotiveGrid.ItemsSource = _locomotiveStates;
+            RefreshData();
+        }
+
+        public void RefreshData()
+        {
+            LoadSummary();
+            LoadHistory();
+            LoadLocomotiveStates();
+        }
+
+        private void LoadSummary()
+        {
+            _summaries.Clear();
+            var counts = _repository.GetTableCounts();
+            var trackCounts = _repository.GetTrackKindCounts();
+
+            AddSummary("Séries", counts.GetValueOrDefault("series"));
+            AddSummary("Locomotives", counts.GetValueOrDefault("locomotives"));
+            AddSummary("Lieux (tuiles)", counts.GetValueOrDefault("tiles"));
+            AddSummary("Voies", counts.GetValueOrDefault("tracks"));
+            AddSummary("Assignations", counts.GetValueOrDefault("track_locomotives"));
+            AddSummary("Historique", counts.GetValueOrDefault("history"));
+            AddSummary("Lieux enregistrés", counts.GetValueOrDefault("places"));
+
+            if (trackCounts.Any())
+            {
+                foreach (var entry in trackCounts.OrderBy(k => k.Key))
+                {
+                    AddSummary($"Voies ({entry.Key})", entry.Value);
+                }
+            }
+        }
+
+        private void AddSummary(string name, int count)
+        {
+            _summaries.Add(new TableSummary
+            {
+                Name = name,
+                Count = count
+            });
+        }
+
+        private void LoadHistory()
+        {
+            _history.Clear();
+            foreach (var entry in _repository.LoadHistory())
+            {
+                _history.Add(entry);
+            }
+        }
+
+        private void LoadLocomotiveStates()
+        {
+            _locomotiveStates.Clear();
+            foreach (var loco in _locomotives.OrderBy(l => l.Number))
+            {
+                _locomotiveStates.Add(new LocomotiveStateRow
+                {
+                    Number = loco.Number,
+                    Pool = loco.Pool,
+                    Status = loco.Status.ToString(),
+                    TractionPercent = loco.TractionPercent?.ToString() ?? string.Empty,
+                    HsReason = loco.HsReason ?? string.Empty
+                });
+            }
+        }
+
+        private void ClearHistory_Click(object sender, RoutedEventArgs e)
+        {
+            var result = MessageBox.Show("Voulez-vous vraiment vider l'historique ?",
+                "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            try
+            {
+                _repository.ClearHistory();
+                MessageBox.Show("Nettoyage terminé : historique vidé.", "Information",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Erreur lors du nettoyage de l'historique : {ex.Message}", "Erreur",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            RefreshData();
+        }
+
+        private void ClearTempData_Click(object sender, RoutedEventArgs e)
+        {
+            var result = MessageBox.Show("Voulez-vous vraiment supprimer les données temporaires ?",
+                "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            var deleted = new List<string>();
+            try
+            {
+                var basePath = AppDomain.CurrentDomain.BaseDirectory;
+                deleted.AddRange(DeleteIfExists(Path.Combine(basePath, "SwapLog.txt")));
+                deleted.AddRange(DeleteIfExists(Path.Combine(basePath, "StatutModificationLog.txt")));
+
+                if (!deleted.Any())
+                {
+                    MessageBox.Show("Aucune donnée temporaire à supprimer.", "Information",
+                        MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+                else
+                {
+                    MessageBox.Show("Nettoyage terminé : données temporaires supprimées.", "Information",
+                        MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Erreur lors du nettoyage des données temporaires : {ex.Message}", "Erreur",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            RefreshData();
+        }
+
+        private static IEnumerable<string> DeleteIfExists(string path)
+        {
+            if (!File.Exists(path))
+            {
+                return Array.Empty<string>();
+            }
+
+            File.Delete(path);
+            return new[] { path };
+        }
+
+        private void ResetOperationalState_Click(object sender, RoutedEventArgs e)
+        {
+            var result = MessageBox.Show("Voulez-vous vraiment réinitialiser les données d'état (traction, raisons HS, incidents en ligne) ?",
+                "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            try
+            {
+                _repository.ResetOperationalState();
+                foreach (var loco in _locomotives)
+                {
+                    loco.TractionPercent = null;
+                    loco.HsReason = null;
+                }
+                foreach (var track in _tiles.SelectMany(tile => tile.Tracks))
+                {
+                    if (track.Kind != TrackKind.Line)
+                    {
+                        continue;
+                    }
+
+                    track.IsOnTrain = false;
+                    track.TrainNumber = null;
+                    track.StopTime = null;
+                    track.IssueReason = null;
+                    track.IsLocomotiveHs = false;
+                }
+                MessageBox.Show("Nettoyage terminé : données d'état réinitialisées.", "Information",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Erreur lors de la réinitialisation : {ex.Message}", "Erreur",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            RefreshData();
+        }
+
+        private sealed class TableSummary
+        {
+            public string Name { get; set; } = string.Empty;
+            public int Count { get; set; }
+        }
+
+        private sealed class LocomotiveStateRow
+        {
+            public int Number { get; set; }
+            public string Pool { get; set; } = string.Empty;
+            public string Status { get; set; } = string.Empty;
+            public string TractionPercent { get; set; } = string.Empty;
+            public string HsReason { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Ploco/Dialogs/LinePlaceDialog.xaml
+++ b/Ploco/Dialogs/LinePlaceDialog.xaml
@@ -1,0 +1,45 @@
+<Window x:Class="Ploco.Dialogs.LinePlaceDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configurer un lieu en ligne" Height="520" Width="460"
+        WindowStartupLocation="CenterOwner">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="12">
+            <TextBlock Text="Nom du lieu" FontWeight="SemiBold"/>
+            <TextBox x:Name="PlaceNameText" Margin="0,6,0,12"/>
+
+            <TextBlock Text="Nom de la voie" FontWeight="SemiBold"/>
+            <TextBox x:Name="TrackNameText" Margin="0,6,0,12"/>
+
+            <TextBlock Text="Locomotives à ajouter (séparées par espace ou virgule)" FontWeight="SemiBold"/>
+            <TextBox x:Name="LocomotiveNumbersText" Margin="0,6,0,12"/>
+
+            <TextBlock Text="Raison de l'incident" FontWeight="SemiBold"/>
+            <TextBox x:Name="IssueReasonText" Margin="0,6,0,12"/>
+
+            <CheckBox x:Name="OnTrainCheck" Content="Locomotive sur un train ?" Margin="0,0,0,6"
+                      Checked="OnTrainCheck_Checked" Unchecked="OnTrainCheck_Checked"/>
+
+            <StackPanel x:Name="TrainDetailsPanel" Visibility="Collapsed">
+                <TextBlock Text="Numéro de train" FontWeight="SemiBold"/>
+                <TextBox x:Name="TrainNumberText" Margin="0,6,0,12"/>
+
+                <TextBlock Text="Heure d'arrêt" FontWeight="SemiBold"/>
+                <TextBox x:Name="StopTimeText" Margin="0,6,0,12"/>
+            </StackPanel>
+
+            <CheckBox x:Name="IsHsCheck" Content="Locomotive HS ?" Margin="0,0,0,6"
+                      Checked="IsHsCheck_Checked" Unchecked="IsHsCheck_Checked"/>
+
+            <StackPanel x:Name="HsLocomotivesPanel" Visibility="Collapsed">
+                <TextBlock Text="Locomotives HS (séparées par espace ou virgule)" FontWeight="SemiBold"/>
+                <TextBox x:Name="HsLocomotivesText" Margin="0,6,0,12"/>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+                <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Window>

--- a/Ploco/Dialogs/LinePlaceDialog.xaml.cs
+++ b/Ploco/Dialogs/LinePlaceDialog.xaml.cs
@@ -1,0 +1,76 @@
+using System.Windows;
+
+namespace Ploco.Dialogs
+{
+    public partial class LinePlaceDialog : Window
+    {
+        public LinePlaceDialog(string? placeName = null)
+        {
+            InitializeComponent();
+            if (!string.IsNullOrWhiteSpace(placeName))
+            {
+                PlaceNameText.Text = placeName;
+            }
+        }
+
+        public string PlaceName => PlaceNameText.Text.Trim();
+        public string TrackName => TrackNameText.Text.Trim();
+        public string LocomotiveNumbers => LocomotiveNumbersText.Text.Trim();
+        public string IssueReason => IssueReasonText.Text.Trim();
+        public bool IsOnTrain => OnTrainCheck.IsChecked == true;
+        public string TrainNumber => TrainNumberText.Text.Trim();
+        public string StopTime => StopTimeText.Text.Trim();
+        public bool IsLocomotiveHs => IsHsCheck.IsChecked == true;
+        public string HsLocomotiveNumbers => HsLocomotivesText.Text.Trim();
+
+        private void OnTrainCheck_Checked(object sender, RoutedEventArgs e)
+        {
+            TrainDetailsPanel.Visibility = OnTrainCheck.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void IsHsCheck_Checked(object sender, RoutedEventArgs e)
+        {
+            HsLocomotivesPanel.Visibility = IsHsCheck.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(PlaceName))
+            {
+                MessageBox.Show("Veuillez saisir un nom de lieu.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(TrackName))
+            {
+                MessageBox.Show("Veuillez saisir un nom de voie.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(IssueReason))
+            {
+                MessageBox.Show("Veuillez saisir une raison d'incident.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (IsOnTrain && string.IsNullOrWhiteSpace(TrainNumber))
+            {
+                MessageBox.Show("Veuillez saisir le numéro du train.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (IsLocomotiveHs && string.IsNullOrWhiteSpace(HsLocomotiveNumbers))
+            {
+                MessageBox.Show("Veuillez saisir les locomotives HS.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/LineTrackDialog.xaml
+++ b/Ploco/Dialogs/LineTrackDialog.xaml
@@ -1,0 +1,31 @@
+<Window x:Class="Ploco.Dialogs.LineTrackDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configurer une voie" Height="360" Width="420"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="12">
+        <TextBlock Text="Nom de la voie" FontWeight="SemiBold"/>
+        <TextBox x:Name="TrackNameText" Margin="0,6,0,12"/>
+
+        <CheckBox x:Name="OnTrainCheck" Content="Locomotive sur un train ?" Margin="0,0,0,6"
+                  Checked="OnTrainCheck_Checked" Unchecked="OnTrainCheck_Checked"/>
+
+        <StackPanel x:Name="TrainDetailsPanel" Visibility="Collapsed">
+            <TextBlock Text="Numéro de train" FontWeight="SemiBold"/>
+            <TextBox x:Name="TrainNumberText" Margin="0,6,0,12"/>
+
+            <TextBlock Text="Heure d'arrêt" FontWeight="SemiBold"/>
+            <TextBox x:Name="StopTimeText" Margin="0,6,0,12"/>
+        </StackPanel>
+
+        <TextBlock Text="Raison du problème" FontWeight="SemiBold"/>
+        <TextBox x:Name="IssueReasonText" Margin="0,6,0,12"/>
+
+        <CheckBox x:Name="IsHsCheck" Content="Locomotive HS ?" Margin="0,0,0,12"/>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Ploco/Dialogs/LineTrackDialog.xaml.cs
+++ b/Ploco/Dialogs/LineTrackDialog.xaml.cs
@@ -1,0 +1,60 @@
+using System.Windows;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class LineTrackDialog : Window
+    {
+        public LineTrackDialog()
+        {
+            InitializeComponent();
+        }
+
+        public TrackModel BuildTrack()
+        {
+            var isOnTrain = OnTrainCheck.IsChecked == true;
+            return new TrackModel
+            {
+                Name = TrackNameText.Text.Trim(),
+                IsOnTrain = isOnTrain,
+                TrainNumber = isOnTrain ? TrainNumberText.Text.Trim() : null,
+                StopTime = isOnTrain ? StopTimeText.Text.Trim() : null,
+                IssueReason = IssueReasonText.Text.Trim(),
+                IsLocomotiveHs = IsHsCheck.IsChecked == true
+            };
+        }
+
+        private void OnTrainCheck_Checked(object sender, RoutedEventArgs e)
+        {
+            TrainDetailsPanel.Visibility = OnTrainCheck.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(TrackNameText.Text))
+            {
+                MessageBox.Show("Veuillez saisir un nom de voie.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(IssueReasonText.Text))
+            {
+                MessageBox.Show("Veuillez saisir une raison.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (OnTrainCheck.IsChecked == true && string.IsNullOrWhiteSpace(TrainNumberText.Text))
+            {
+                MessageBox.Show("Veuillez saisir un numéro de train.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/PlaceDialog.xaml
+++ b/Ploco/Dialogs/PlaceDialog.xaml
@@ -1,0 +1,37 @@
+<Window x:Class="Ploco.Dialogs.PlaceDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Ajouter un lieu" Height="260" Width="420"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="12">
+        <TextBlock Text="Type de lieu" FontWeight="SemiBold"/>
+        <ComboBox x:Name="TypeCombo" Margin="0,6,0,12" SelectionChanged="TypeCombo_SelectionChanged">
+            <ComboBoxItem Content="Dépôt" Tag="Depot"/>
+            <ComboBoxItem Content="Garage" Tag="VoieGarage"/>
+            <ComboBoxItem Content="En ligne" Tag="ArretLigne"/>
+            <ComboBoxItem Content="Ligne de roulement" Tag="LigneRoulement"/>
+        </ComboBox>
+
+        <StackPanel x:Name="DepotPanel" Visibility="Collapsed">
+            <TextBlock Text="Nom du dépôt" FontWeight="SemiBold"/>
+            <ComboBox x:Name="DepotNameCombo" Margin="0,6,0,12"/>
+        </StackPanel>
+
+        <StackPanel x:Name="GaragePanel" Visibility="Collapsed">
+            <TextBlock Text="Nom du garage" FontWeight="SemiBold"/>
+            <ComboBox x:Name="GarageNameCombo" Margin="0,6,0,6" SelectionChanged="GarageNameCombo_SelectionChanged"/>
+            <TextBlock x:Name="CustomGarageLabel" Text="Nom personnalisé" FontWeight="SemiBold" Visibility="Collapsed"/>
+            <TextBox x:Name="CustomGarageName" Margin="0,6,0,12" Visibility="Collapsed"/>
+        </StackPanel>
+
+        <StackPanel x:Name="RollingLinePanel" Visibility="Collapsed">
+            <TextBlock Text="Nom de la ligne de roulement" FontWeight="SemiBold"/>
+            <TextBox x:Name="RollingLineName" Margin="0,6,0,12" Text="Ligne de roulement"/>
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Ploco/Dialogs/PlaceDialog.xaml.cs
+++ b/Ploco/Dialogs/PlaceDialog.xaml.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class PlaceDialog : Window
+    {
+        private static readonly string[] DepotNames =
+        {
+            "Hausbergen",
+            "Mulhouse Nord",
+            "Thionville",
+            "Woippy"
+        };
+
+        private static readonly string[] GarageNames =
+        {
+            "Anvers Nord",
+            "Bale",
+            "Bettembourg",
+            "Chatelet",
+            "Gent",
+            "La Louviere",
+            "Luxembourg",
+            "Monceau",
+            "Ronet",
+            "SRH",
+            "Uckange",
+            "Zeebrugge",
+            "Autres"
+        };
+
+        public TileType SelectedType { get; private set; }
+        public string SelectedName { get; private set; } = string.Empty;
+
+        public PlaceDialog()
+        {
+            InitializeComponent();
+            DepotNameCombo.ItemsSource = DepotNames;
+            GarageNameCombo.ItemsSource = GarageNames;
+            TypeCombo.SelectedIndex = 0;
+        }
+
+        private void TypeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            DepotPanel.Visibility = Visibility.Collapsed;
+            GaragePanel.Visibility = Visibility.Collapsed;
+            RollingLinePanel.Visibility = Visibility.Collapsed;
+            if (TypeCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                SelectedType = Enum.Parse<TileType>(tag);
+            }
+
+            switch (SelectedType)
+            {
+                case TileType.Depot:
+                    DepotPanel.Visibility = Visibility.Visible;
+                    DepotNameCombo.SelectedIndex = 0;
+                    break;
+                case TileType.VoieGarage:
+                    GaragePanel.Visibility = Visibility.Visible;
+                    GarageNameCombo.SelectedIndex = 0;
+                    break;
+                case TileType.ArretLigne:
+                    break;
+                case TileType.LigneRoulement:
+                    RollingLinePanel.Visibility = Visibility.Visible;
+                    break;
+            }
+        }
+
+        private void GarageNameCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var selected = GarageNameCombo.SelectedItem as string;
+            var showCustom = string.Equals(selected, "Autres");
+            CustomGarageLabel.Visibility = showCustom ? Visibility.Visible : Visibility.Collapsed;
+            CustomGarageName.Visibility = showCustom ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedName = SelectedType switch
+            {
+                TileType.Depot => DepotNameCombo.SelectedItem as string ?? string.Empty,
+                TileType.VoieGarage => ResolveGarageName(),
+                TileType.ArretLigne => string.Empty,
+                TileType.LigneRoulement => RollingLineName.Text.Trim(),
+                _ => string.Empty
+            };
+
+            if (SelectedType != TileType.ArretLigne && string.IsNullOrWhiteSpace(SelectedName))
+            {
+                MessageBox.Show("Veuillez saisir un nom valide.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            DialogResult = true;
+        }
+
+        private string ResolveGarageName()
+        {
+            var selected = GarageNameCombo.SelectedItem as string ?? string.Empty;
+            if (string.Equals(selected, "Autres"))
+            {
+                return CustomGarageName.Text.Trim();
+            }
+
+            return selected;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/StatusDialog.xaml
+++ b/Ploco/Dialogs/StatusDialog.xaml
@@ -1,16 +1,27 @@
 <Window x:Class="Ploco.Dialogs.StatusDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Modifier statut" Height="200" Width="300"
+        Title="Modifier le statut" Height="320" Width="360"
         WindowStartupLocation="CenterOwner">
     <StackPanel Margin="12">
         <TextBlock x:Name="LocoLabel" Margin="0,0,0,10" FontWeight="Bold"/>
-        <ComboBox x:Name="StatusCombo" Margin="0,0,0,12">
-            <ComboBoxItem Content="Ok" Tag="Ok"/>
-            <ComboBoxItem Content="Défaut mineur" Tag="DefautMineur"/>
-            <ComboBoxItem Content="À contrôler" Tag="AControler"/>
+        <ComboBox x:Name="StatusCombo" Margin="0,0,0,12" SelectionChanged="StatusCombo_SelectionChanged">
+            <ComboBoxItem Content="OK" Tag="Ok"/>
+            <ComboBoxItem Content="Manque de traction" Tag="ManqueTraction"/>
             <ComboBoxItem Content="HS" Tag="HS"/>
         </ComboBox>
+
+        <StackPanel x:Name="TractionPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Nombre de moteurs HS sur 4" FontWeight="SemiBold"/>
+            <TextBox x:Name="TractionMotorsText" Margin="0,6,0,4"/>
+            <TextBlock x:Name="TractionHint" Foreground="SlateGray"/>
+        </StackPanel>
+
+        <StackPanel x:Name="HsPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Raison HS" FontWeight="SemiBold"/>
+            <TextBox x:Name="HsReasonText" Margin="0,6,0,0"/>
+        </StackPanel>
+
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
             <Button Content="Annuler" Width="80" Click="Cancel_Click"/>

--- a/Ploco/Dialogs/StatusDialog.xaml.cs
+++ b/Ploco/Dialogs/StatusDialog.xaml.cs
@@ -9,12 +9,26 @@ namespace Ploco.Dialogs
     {
         private readonly LocomotiveModel _locomotive;
 
-        public StatusDialog(LocomotiveModel locomotive)
+        public StatusDialog(LocomotiveModel locomotive, LocomotiveStatus? forcedStatus = null)
         {
             InitializeComponent();
             _locomotive = locomotive;
             LocoLabel.Text = locomotive.DisplayName;
-            StatusCombo.SelectedIndex = (int)locomotive.Status;
+            StatusCombo.SelectedIndex = (int)(forcedStatus ?? locomotive.Status);
+            TractionMotorsText.Text = locomotive.TractionPercent.HasValue
+                ? TractionPercentToMotors(locomotive.TractionPercent.Value).ToString()
+                : string.Empty;
+            HsReasonText.Text = locomotive.HsReason ?? string.Empty;
+            if (forcedStatus.HasValue)
+            {
+                StatusCombo.IsEnabled = false;
+            }
+            UpdatePanels();
+        }
+
+        private void StatusCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdatePanels();
         }
 
         private void Validate_Click(object sender, RoutedEventArgs e)
@@ -22,6 +36,43 @@ namespace Ploco.Dialogs
             if (StatusCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag &&
                 Enum.TryParse(tag, out LocomotiveStatus status))
             {
+                if (status == LocomotiveStatus.ManqueTraction)
+                {
+                    if (!int.TryParse(TractionMotorsText.Text.Trim(), out var motorsHs) || motorsHs < 1 || motorsHs > 4)
+                    {
+                        MessageBox.Show("Saisissez un nombre de moteurs HS entre 1 et 4.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
+
+                    if (motorsHs == 4)
+                    {
+                        MessageBox.Show("4 moteurs HS : passez la locomotive en statut HS.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
+
+                    _locomotive.TractionPercent = MotorsToTractionPercent(motorsHs);
+                    _locomotive.HsReason = null;
+                }
+                else
+                {
+                    _locomotive.TractionPercent = null;
+                }
+
+                if (status == LocomotiveStatus.HS)
+                {
+                    if (string.IsNullOrWhiteSpace(HsReasonText.Text))
+                    {
+                        MessageBox.Show("Veuillez renseigner une raison HS.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        return;
+                    }
+
+                    _locomotive.HsReason = HsReasonText.Text.Trim();
+                }
+                else
+                {
+                    _locomotive.HsReason = null;
+                }
+
                 _locomotive.Status = status;
                 DialogResult = true;
                 return;
@@ -33,6 +84,49 @@ namespace Ploco.Dialogs
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {
             DialogResult = false;
+        }
+
+        private void UpdatePanels()
+        {
+            var status = GetSelectedStatus();
+            TractionPanel.Visibility = status == LocomotiveStatus.ManqueTraction ? Visibility.Visible : Visibility.Collapsed;
+            HsPanel.Visibility = status == LocomotiveStatus.HS ? Visibility.Visible : Visibility.Collapsed;
+            TractionHint.Text = status == LocomotiveStatus.ManqueTraction
+                ? "1 moteur HS = 75% · 2 moteurs HS = 50% · 3 moteurs HS = 25%"
+                : string.Empty;
+        }
+
+        private LocomotiveStatus? GetSelectedStatus()
+        {
+            if (StatusCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag &&
+                Enum.TryParse(tag, out LocomotiveStatus status))
+            {
+                return status;
+            }
+
+            return null;
+        }
+
+        private static int MotorsToTractionPercent(int motorsHs)
+        {
+            return motorsHs switch
+            {
+                1 => 75,
+                2 => 50,
+                3 => 25,
+                _ => 0
+            };
+        }
+
+        private static int TractionPercentToMotors(int percent)
+        {
+            return percent switch
+            {
+                75 => 1,
+                50 => 2,
+                25 => 3,
+                _ => 0
+            };
         }
     }
 }

--- a/Ploco/Dialogs/TapisT13Window.xaml
+++ b/Ploco/Dialogs/TapisT13Window.xaml
@@ -1,0 +1,75 @@
+<Window x:Class="Ploco.Dialogs.TapisT13Window"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Tapis T13" Height="520" Width="680"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0">
+                <TextBlock Text="Synthèse des locomotives T13 (pool Sibelit)" FontWeight="Bold"/>
+                <TextBlock x:Name="SummaryText" Foreground="SlateGray"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Actualiser" Margin="4,0" Click="Refresh_Click"/>
+                <Button Content="Copier colonne Locomotive" Margin="4,0" Click="CopyLocomotive_Click"/>
+                <Button Content="Copier colonne Loc HS" Margin="4,0" Click="CopyLocHs_Click"/>
+                <Button Content="Copier colonne Infos/Rapport" Margin="4,0" Click="CopyReport_Click"/>
+            </StackPanel>
+        </Grid>
+
+        <DataGrid Grid.Row="1"
+                  x:Name="T13Grid"
+                  AutoGenerateColumns="False"
+                  HeadersVisibility="Column"
+                  IsReadOnly="True"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False"
+                  CanUserReorderColumns="False"
+                  CanUserResizeRows="False"
+                  CanUserSortColumns="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Locomotive" Binding="{Binding Locomotive}" Width="*"/>
+                <DataGridTextColumn Header="Date entretien" Binding="{Binding DateEntretien}" Width="*"/>
+                <DataGridTextColumn Header="Statut / Motif" Binding="{Binding Motif}" Width="*"/>
+                <DataGridTextColumn Header="Loc HS" Binding="{Binding LocHs}" Width="*">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Foreground" Value="Black"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsHs}" Value="True">
+                                    <Setter Property="Foreground" Value="Red"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Infos / Rapport" Binding="{Binding Report}" Width="*">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Foreground" Value="Black"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsHs}" Value="True">
+                                    <Setter Property="Foreground" Value="Red"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button Content="Fermer" Width="90" Click="Close_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using Ploco.Helpers;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class TapisT13Window : Window, IRefreshableWindow
+    {
+        private readonly ObservableCollection<T13Row> _rows = new();
+        private readonly IEnumerable<LocomotiveModel> _locomotives;
+        private readonly IEnumerable<TileModel> _tiles;
+
+        public TapisT13Window(IEnumerable<LocomotiveModel> locomotives, IEnumerable<TileModel> tiles)
+        {
+            InitializeComponent();
+            T13Grid.ItemsSource = _rows;
+            _locomotives = locomotives;
+            _tiles = tiles;
+            LoadRows(_locomotives, _tiles);
+        }
+
+        private void LoadRows(IEnumerable<LocomotiveModel> locomotives, IEnumerable<TileModel> tiles)
+        {
+            _rows.Clear();
+            var tracks = tiles.SelectMany(tile => tile.Tracks).ToList();
+
+            foreach (var loco in locomotives
+                         .Where(l => IsT13(l) && string.Equals(l.Pool, "Sibelit", StringComparison.OrdinalIgnoreCase))
+                         .OrderBy(l => l.Number))
+            {
+                var track = tracks.FirstOrDefault(t => t.Locomotives.Contains(loco));
+                var location = ResolveLocation(track, tiles);
+                var trainInfo = track?.IsOnTrain == true
+                    ? string.IsNullOrWhiteSpace(track.TrainNumber)
+                        ? location
+                        : $"{location} {track.TrainNumber}"
+                    : location;
+
+                var rollingLineNumber = ResolveRollingLineNumber(loco, tiles);
+                var rollingLineInfo = rollingLineNumber.HasValue ? rollingLineNumber.Value.ToString() : string.Empty;
+                var isHs = loco.Status == LocomotiveStatus.HS;
+                var locHs = isHs ? (string.IsNullOrWhiteSpace(rollingLineInfo) ? trainInfo : rollingLineInfo) : string.Empty;
+                var report = string.IsNullOrWhiteSpace(rollingLineInfo) ? (isHs ? trainInfo : string.Empty) : rollingLineInfo;
+                var motif = isHs ? (loco.HsReason ?? string.Empty) : string.Empty;
+
+                _rows.Add(new T13Row
+                {
+                    Locomotive = loco.Number.ToString(),
+                    DateEntretien = loco.MaintenanceDate ?? string.Empty,
+                    Motif = motif,
+                    LocHs = locHs,
+                    Report = report,
+                    IsHs = isHs
+                });
+            }
+
+            UpdateSummary();
+        }
+
+        private static bool IsT13(LocomotiveModel loco)
+        {
+            return loco.SeriesName.Contains("1300", StringComparison.OrdinalIgnoreCase)
+                   || loco.SeriesName.Contains("T13", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ResolveLocation(TrackModel? track, IEnumerable<TileModel> tiles)
+        {
+            if (track == null)
+            {
+                return string.Empty;
+            }
+
+            var tile = tiles.FirstOrDefault(t => t.Tracks.Contains(track));
+            if (tile == null)
+            {
+                return track.Name;
+            }
+
+            return GetLocationAbbreviation(tile.Name);
+        }
+
+        private static int? ResolveRollingLineNumber(LocomotiveModel locomotive, IEnumerable<TileModel> tiles)
+        {
+            foreach (var line in tiles.SelectMany(tile => tile.RollingLines))
+            {
+                if (line.Locomotives.Contains(locomotive))
+                {
+                    return line.Number;
+                }
+            }
+
+            return null;
+        }
+
+        private static string GetLocationAbbreviation(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return name;
+            }
+
+            var normalized = name.Trim();
+            return normalized switch
+            {
+                "Thionville" => "THL",
+                "SRH" => "SRH",
+                "Anvers Nord" => "FN",
+                "Anvers" => "FN",
+                "Mulhouse Nord" => "MUN",
+                "Mulhouse" => "MUN",
+                "Bale" => "BAL",
+                "Woippy" => "WPY",
+                "Uckange" => "UCK",
+                "Zeebrugge" => "LZR",
+                "Gent" => "FGZH",
+                "Muizen" => "FIZ",
+                "Monceau" => "LNC",
+                "La Louviere" => "GLI",
+                "Chatelet" => "FCL",
+                _ => normalized
+            };
+        }
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void CopyLocomotive_Click(object sender, RoutedEventArgs e)
+        {
+            CopyColumn(row => row.Locomotive);
+        }
+
+        private void CopyLocHs_Click(object sender, RoutedEventArgs e)
+        {
+            CopyColumn(row => row.LocHs);
+        }
+
+        private void CopyReport_Click(object sender, RoutedEventArgs e)
+        {
+            CopyColumn(row => row.Report);
+        }
+
+        private void Refresh_Click(object sender, RoutedEventArgs e)
+        {
+            RefreshData();
+        }
+
+        private void CopyColumn(Func<T13Row, string> selector)
+        {
+            var text = string.Join(Environment.NewLine, _rows.Select(selector));
+            Clipboard.SetText(text);
+        }
+
+        private void UpdateSummary()
+        {
+            var total = _rows.Count;
+            var hsCount = _rows.Count(r => r.IsHs);
+            var okCount = total - hsCount;
+            SummaryText.Text = $"Total : {total} · HS : {hsCount} · OK : {okCount}";
+        }
+
+        public void RefreshData()
+        {
+            var selected = T13Grid.SelectedItem as T13Row;
+            var selectedKey = selected?.Locomotive;
+            LoadRows(_locomotives, _tiles);
+            if (!string.IsNullOrWhiteSpace(selectedKey))
+            {
+                var row = _rows.FirstOrDefault(item => item.Locomotive == selectedKey);
+                if (row != null)
+                {
+                    T13Grid.SelectedItem = row;
+                }
+            }
+        }
+
+        private sealed class T13Row
+        {
+            public string Locomotive { get; set; } = string.Empty;
+            public string DateEntretien { get; set; } = string.Empty;
+            public string Motif { get; set; } = string.Empty;
+            public string LocHs { get; set; } = string.Empty;
+            public string Report { get; set; } = string.Empty;
+            public bool IsHs { get; set; }
+        }
+    }
+}

--- a/Ploco/Helpers/ContextMenuHelper.cs
+++ b/Ploco/Helpers/ContextMenuHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using Ploco.Dialogs;
 using Ploco.Models;
 
 namespace Ploco.Helpers
@@ -23,63 +24,71 @@ namespace Ploco.Helpers
         /// Une action à appeler pour mettre à jour l'interface après l'échange.
         /// </param>
         public static void HandleSwap(object sender,
-                              ObservableCollection<Locomotive> lineasPool,
-                              ObservableCollection<Locomotive> sibelitPool,
-                              Func<Locomotive, Border> findCanvasItemForLoco,
-                              Action updateInfoZone)
+                              ObservableCollection<LocomotiveModel> lineasPool,
+                              ObservableCollection<LocomotiveModel> sibelitPool,
+                              Func<LocomotiveModel, Border>? findCanvasItemForLoco,
+                              Action? updateInfoZone)
         {
-            MenuItem menuItem = sender as MenuItem;
-            if (menuItem == null) return;
-
-            ContextMenu contextMenu = menuItem.Parent as ContextMenu;
-            if (contextMenu == null) return;
-
-            // Le PlacementTarget est l'élément sur lequel on a cliqué.
-            Border border = contextMenu.PlacementTarget as Border;
-            if (border == null) return;
-
-            // Récupérer la locomotive depuis le DataContext ou le Tag.
-            Locomotive locoFromSibelit = border.DataContext as Locomotive ?? border.Tag as Locomotive;
-            if (locoFromSibelit == null) return;
-
-            // Ouvrir la fenêtre de swap en passant la locomotive de Sibelit et le pool Lineas.
-            SwapDialog dialog = new SwapDialog(locoFromSibelit, lineasPool);
-            bool? result = dialog.ShowDialog();
-            if (result == true)
+            if (sender is not MenuItem menuItem)
             {
-                // Récupérer la locomotive sélectionnée dans le SwapDialog.
-                Locomotive locoFromLineas = dialog.SelectedLoco;
-                if (locoFromLineas != null)
+                return;
+            }
+
+            if (menuItem.Parent is not ContextMenu contextMenu)
+            {
+                return;
+            }
+
+            if (contextMenu.PlacementTarget is not Border border)
+            {
+                return;
+            }
+
+            var locoFromSibelit = border.DataContext as LocomotiveModel ?? border.Tag as LocomotiveModel;
+            if (locoFromSibelit == null)
+            {
+                return;
+            }
+
+            var dialog = new SwapDialog(locoFromSibelit, lineasPool);
+            if (dialog.ShowDialog() != true || dialog.SelectedLoco == null)
+            {
+                return;
+            }
+
+            var locoFromLineas = dialog.SelectedLoco;
+
+            if (findCanvasItemForLoco != null)
+            {
+                var canvasItem = findCanvasItemForLoco(locoFromSibelit);
+                if (canvasItem?.Parent is Canvas canvas)
                 {
-                    // Si la locomotive de Sibelit est sur le Canvas, la retirer.
-                    if (findCanvasItemForLoco != null)
-                    {
-                        Border canvasItem = findCanvasItemForLoco(locoFromSibelit);
-                        if (canvasItem != null && canvasItem.Parent is Canvas canvas)
-                        {
-                            canvas.Children.Remove(canvasItem);
-                            locoFromSibelit.IsOnCanvas = false;
-                        }
-                    }
-
-                    // Effectuer l'échange dans les collections.
-                    if (sibelitPool.Contains(locoFromSibelit))
-                        sibelitPool.Remove(locoFromSibelit);
-                    if (!lineasPool.Contains(locoFromSibelit))
-                        lineasPool.Add(locoFromSibelit);
-
-                    if (lineasPool.Contains(locoFromLineas))
-                        lineasPool.Remove(locoFromLineas);
-                    if (!sibelitPool.Contains(locoFromLineas))
-                        sibelitPool.Add(locoFromLineas);
-
-                    // Mettre à jour les propriétés CurrentPool pour refléter l'échange.
-                    locoFromSibelit.CurrentPool = "Lineas";
-                    locoFromLineas.CurrentPool = "Sibelit";
-
-                    updateInfoZone?.Invoke();
+                    canvas.Children.Remove(canvasItem);
                 }
             }
+
+            if (sibelitPool.Contains(locoFromSibelit))
+            {
+                sibelitPool.Remove(locoFromSibelit);
+            }
+            if (!lineasPool.Contains(locoFromSibelit))
+            {
+                lineasPool.Add(locoFromSibelit);
+            }
+
+            if (lineasPool.Contains(locoFromLineas))
+            {
+                lineasPool.Remove(locoFromLineas);
+            }
+            if (!sibelitPool.Contains(locoFromLineas))
+            {
+                sibelitPool.Add(locoFromLineas);
+            }
+
+            locoFromSibelit.Pool = "Lineas";
+            locoFromLineas.Pool = "Sibelit";
+
+            updateInfoZone?.Invoke();
         }
 
         /// <summary>
@@ -89,27 +98,31 @@ namespace Ploco.Helpers
         /// <param name="updateInfoZone">
         /// Une action à appeler pour mettre à jour l'interface après modification du statut.
         /// </param>
-        public static void HandleModifierStatut(object sender, Action updateInfoZone)
+        public static void HandleModifierStatut(object sender, Action? updateInfoZone)
         {
-            MenuItem menuItem = sender as MenuItem;
-            if (menuItem == null)
+            if (sender is not MenuItem menuItem)
+            {
                 return;
+            }
 
-            ContextMenu contextMenu = menuItem.Parent as ContextMenu;
-            if (contextMenu == null)
+            if (menuItem.Parent is not ContextMenu contextMenu)
+            {
                 return;
+            }
 
-            Border border = contextMenu.PlacementTarget as Border;
-            if (border == null)
+            if (contextMenu.PlacementTarget is not Border border)
+            {
                 return;
+            }
 
-            Locomotive loco = border.DataContext as Locomotive ?? border.Tag as Locomotive;
+            var loco = border.DataContext as LocomotiveModel ?? border.Tag as LocomotiveModel;
             if (loco == null)
+            {
                 return;
+            }
 
-            ModifierStatutDialog dialog = new ModifierStatutDialog(loco);
-            bool? result = dialog.ShowDialog();
-            if (result == true)
+            var dialog = new StatusDialog(loco);
+            if (dialog.ShowDialog() == true)
             {
                 updateInfoZone?.Invoke();
             }
@@ -120,17 +133,8 @@ namespace Ploco.Helpers
         /// </summary>
         public static void HandleVoirHistorique(object sender, Window owner)
         {
-            MenuItem menuItem = sender as MenuItem;
-            if (menuItem?.Parent is ContextMenu contextMenu && contextMenu.PlacementTarget is Border border)
-            {
-                Locomotive loco = border.DataContext as Locomotive ?? border.Tag as Locomotive;
-                if (loco != null)
-                {
-                    HistoriqueDialog dialog = new HistoriqueDialog(loco);
-                    dialog.Owner = owner;
-                    dialog.ShowDialog();
-                }
-            }
+            MessageBox.Show("L'historique est disponible dans la fenêtre principale.", "Historique",
+                MessageBoxButton.OK, MessageBoxImage.Information);
         }
     }
 }

--- a/Ploco/Helpers/IRefreshableWindow.cs
+++ b/Ploco/Helpers/IRefreshableWindow.cs
@@ -1,0 +1,7 @@
+namespace Ploco.Helpers
+{
+    public interface IRefreshableWindow
+    {
+        void RefreshData();
+    }
+}

--- a/Ploco/Helpers/TileTemplateSelector.cs
+++ b/Ploco/Helpers/TileTemplateSelector.cs
@@ -1,0 +1,31 @@
+using System.Windows;
+using System.Windows.Controls;
+using Ploco.Models;
+
+namespace Ploco.Helpers
+{
+    public class TileTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate? DepotTemplate { get; set; }
+        public DataTemplate? GarageTemplate { get; set; }
+        public DataTemplate? LineTemplate { get; set; }
+        public DataTemplate? RollingLineTemplate { get; set; }
+
+        public override DataTemplate? SelectTemplate(object item, DependencyObject container)
+        {
+            if (item is not TileModel tile)
+            {
+                return base.SelectTemplate(item, container);
+            }
+
+            return tile.Type switch
+            {
+                TileType.Depot => DepotTemplate,
+                TileType.VoieGarage => GarageTemplate,
+                TileType.ArretLigne => LineTemplate,
+                TileType.LigneRoulement => RollingLineTemplate,
+                _ => base.SelectTemplate(item, container)
+            };
+        }
+    }
+}

--- a/Ploco/HistoriqueWindow.xaml.cs
+++ b/Ploco/HistoriqueWindow.xaml.cs
@@ -1,17 +1,20 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
+using Ploco.Models;
 
 namespace Ploco
 {
     public partial class HistoriqueWindow : Window
     {
-        public HistoriqueWindow()
+        public HistoriqueWindow(IEnumerable<HistoryEntry> historyEntries)
         {
             InitializeComponent();
-            // Vérifie si le fichier log existe et le charge
-            if (File.Exists("StatutModificationLog.txt"))
+            var entries = historyEntries?.ToList() ?? new List<HistoryEntry>();
+            if (entries.Any())
             {
-                tbHistorique.Text = File.ReadAllText("StatutModificationLog.txt");
+                tbHistorique.Text = string.Join(Environment.NewLine, entries.Select(entry =>
+                    $"{entry.Timestamp:yyyy-MM-dd HH:mm:ss} | {entry.Action} | {entry.Details}"));
             }
             else
             {

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -2,42 +2,900 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Ploco.Converters"
-        Title="Ploco - Nouvelle version" Height="800" Width="1200"
+        xmlns:helpers="clr-namespace:Ploco.Helpers"
+        Title="Ploco - Gestion de parcs locomotives" Height="800" Width="1200"
         Icon="pack://application:,,,/img/train_logo.ico"
+        Background="{DynamicResource AppBackgroundBrush}"
         Loaded="Window_Loaded" Closing="Window_Closing">
     <Window.Resources>
         <local:StatutToBrushConverter x:Key="StatutToBrushConverter"/>
-        <Style x:Key="TileHeaderButton" TargetType="Button">
-            <Setter Property="Margin" Value="4,0,0,0"/>
-            <Setter Property="Padding" Value="4,0"/>
-            <Setter Property="FontSize" Value="11"/>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <SolidColorBrush x:Key="AppBackgroundBrush" Color="#FFF2F2F2"/>
+        <SolidColorBrush x:Key="PanelBackgroundBrush" Color="#FFEFF4FF"/>
+        <SolidColorBrush x:Key="CanvasBackgroundBrush" Color="#FFF7F7F7"/>
+        <SolidColorBrush x:Key="TileBackgroundBrush" Color="White"/>
+        <SolidColorBrush x:Key="TileBorderBrush" Color="#FFB0B0B0"/>
+        <SolidColorBrush x:Key="TrackBorderBrush" Color="#FFE0E0E0"/>
+        <SolidColorBrush x:Key="ListBackgroundBrush" Color="#FFF5F5F5"/>
+        <SolidColorBrush x:Key="ListBorderBrush" Color="#FFDDDDDD"/>
+        <SolidColorBrush x:Key="AppForegroundBrush" Color="#FF111111"/>
+        <SolidColorBrush x:Key="MenuBackgroundBrush" Color="#FFF2F2F2"/>
+        <SolidColorBrush x:Key="MenuBorderBrush" Color="#FFDDDDDD"/>
+        <SolidColorBrush x:Key="ToolBarBackgroundBrush" Color="#FFF2F2F2"/>
+        <SolidColorBrush x:Key="ToolBarBorderBrush" Color="#FFDDDDDD"/>
+        <Style x:Key="DropListBoxStyle" TargetType="ListBox">
+            <Setter Property="MinHeight" Value="48"/>
+            <Setter Property="Background" Value="{DynamicResource ListBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ListBorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         </Style>
-        <ContextMenu x:Key="LocomotiveContextMenu">
+        <Style TargetType="ListBox">
+            <Setter Property="Background" Value="{DynamicResource ListBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ListBorderBrush}"/>
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style TargetType="Menu">
+            <Setter Property="Background" Value="{DynamicResource MenuBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource MenuBorderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style TargetType="MenuItem">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource MenuBackgroundBrush}"/>
+        </Style>
+        <Style TargetType="ContextMenu">
+            <Setter Property="Background" Value="{DynamicResource MenuBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource MenuBorderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style TargetType="ToolBar">
+            <Setter Property="Background" Value="{DynamicResource ToolBarBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ToolBarBorderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style TargetType="Button">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}"/>
+        </Style>
+        <Style x:Key="BlockedSwitchButtonBase" TargetType="Button">
+            <Setter Property="MinWidth" Value="44"/>
+            <Setter Property="Height" Value="20"/>
+            <Setter Property="Margin" Value="4,0,0,0"/>
+            <Setter Property="Padding" Value="6,0"/>
+            <Setter Property="FontSize" Value="10"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Background" Value="#FF2E7D32"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderBrush" Value="#FF1B5E20"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Content" Value="Libre"/>
+        </Style>
+        <Style x:Key="LeftBlockedSwitchStyle" TargetType="Button" BasedOn="{StaticResource BlockedSwitchButtonBase}">
+            <Setter Property="ToolTip" Value="BLOCK"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsLeftBlocked}" Value="True">
+                    <Setter Property="Background" Value="#FFD32F2F"/>
+                    <Setter Property="BorderBrush" Value="#FFB71C1C"/>
+                    <Setter Property="Content" Value="Plein"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding LeftLabel}" Value="">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="RightBlockedSwitchStyle" TargetType="Button" BasedOn="{StaticResource BlockedSwitchButtonBase}">
+            <Setter Property="ToolTip" Value="BIF"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsRightBlocked}" Value="True">
+                    <Setter Property="Background" Value="#FFD32F2F"/>
+                    <Setter Property="BorderBrush" Value="#FFB71C1C"/>
+                    <Setter Property="Content" Value="Plein"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding RightLabel}" Value="">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <ContextMenu x:Key="LocomotiveTileContextMenu">
             <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
+            <MenuItem Header="Loc HS" Click="MenuItem_LocHs_Click" InputGestureText="Ctrl+H"/>
+            <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
             <MenuItem Header="Retirer de la tuile" Click="MenuItem_RemoveFromTile_Click"/>
         </ContextMenu>
+        <ContextMenu x:Key="LocomotiveListContextMenu">
+            <MenuItem Header="Modifier statut" Click="MenuItem_ModifierStatut_Click"/>
+            <MenuItem Header="Loc HS" Click="MenuItem_LocHs_Click" InputGestureText="Ctrl+H"/>
+            <MenuItem Header="Swap" Click="MenuItem_SwapPool_Click"/>
+        </ContextMenu>
+        <DataTemplate x:Key="DepotTileTemplate">
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="180"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <Grid>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                            <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                <MenuItem Header="...">
+                                    <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Ajouter voie de sortie" Click="AddDepotOutput_Click" Tag="{Binding}"/>
+                                </MenuItem>
+                            </Menu>
+                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
+                                <TextBlock Text="Locomotives" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                                <Grid>
+                                    <ListBox x:Name="DepotMainList"
+                                             DataContext="{Binding MainTrack}"
+                                             ItemsSource="{Binding Locomotives}"
+                                             Style="{StaticResource DropListBoxStyle}"
+                                             AllowDrop="True"
+                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                             Drop="TrackLocomotives_Drop">
+                                        <ListBox.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ListBox.ItemsPanel>
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                            <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                    Padding="4" Margin="2" CornerRadius="4"
+                                                    ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                    PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
+                                                    <Grid>
+                                                        <Grid.RowDefinitions>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                        </Grid.RowDefinitions>
+                                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                   HorizontalAlignment="Left"/>
+                                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                    </Grid>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                    <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding ElementName=DepotMainList, Path=HasItems}" Value="False">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                                <ItemsControl ItemsSource="{Binding OutputTracks}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                                <StackPanel>
+                                                    <DockPanel>
+                                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" DockPanel.Dock="Left"/>
+                                                        <TextBlock Text="Sortie" Foreground="SlateGray" DockPanel.Dock="Right" Margin="8,0,0,0"/>
+                                                    </DockPanel>
+                                                    <Grid>
+                                                        <ListBox x:Name="DepotOutputList"
+                                                                 ItemsSource="{Binding Locomotives}"
+                                                                 Style="{StaticResource DropListBoxStyle}"
+                                                                 AllowDrop="True"
+                                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                                 Drop="TrackLocomotives_Drop">
+                                                            <ListBox.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                    <Canvas />
+                                                                </ItemsPanelTemplate>
+                                                            </ListBox.ItemsPanel>
+                                                            <ListBox.ItemContainerStyle>
+                                                                <Style TargetType="ListBoxItem">
+                                                                    <Setter Property="Canvas.Left" Value="{Binding AssignedTrackOffsetX, TargetNullValue=0}"/>
+                                                                    <Setter Property="Canvas.Top" Value="0"/>
+                                                                </Style>
+                                                            </ListBox.ItemContainerStyle>
+                                                            <ListBox.ItemTemplate>
+                                                                <DataTemplate>
+                                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                                            PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
+                                                                        <Grid>
+                                                                            <Grid.RowDefinitions>
+                                                                                <RowDefinition Height="Auto"/>
+                                                                                <RowDefinition Height="Auto"/>
+                                                                            </Grid.RowDefinitions>
+                                                                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                       HorizontalAlignment="Left"/>
+                                                                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                       HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                                <TextBlock.Style>
+                                                                                    <Style TargetType="TextBlock">
+                                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                                        <Style.Triggers>
+                                                                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                            </DataTrigger>
+                                                                                        </Style.Triggers>
+                                                                                    </Style>
+                                                                                </TextBlock.Style>
+                                                                            </TextBlock>
+                                                                        </Grid>
+                                                                    </Border>
+                                                                </DataTemplate>
+                                                            </ListBox.ItemTemplate>
+                                                        </ListBox>
+                                                        <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                                   HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding ElementName=DepotOutputList, Path=HasItems}" Value="False">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                    </Grid>
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </StackPanel>
+                    <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                           Cursor="SizeNWSE" DragDelta="TileResizeThumb_DragDelta" DragCompleted="TileResizeThumb_DragCompleted"
+                           Background="#55000000" BorderBrush="#FF7A7A7A" BorderThickness="1"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="GarageTileTemplate">
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="180"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <Grid>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                            <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                <MenuItem Header="...">
+                                    <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Ajouter zone" Click="AddGarageZone_Click" Tag="{Binding}"/>
+                                </MenuItem>
+                            </Menu>
+                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
+                                <StackPanel>
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding MainTrack}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
+                                    <TextBlock Text="Zone principale" FontSize="12" Foreground="Gray" Margin="0,4,0,2"/>
+                                    <Grid>
+                                        <ListBox x:Name="GarageMainList"
+                                                 DataContext="{Binding MainTrack}"
+                                                 ItemsSource="{Binding Locomotives}"
+                                                 Style="{StaticResource DropListBoxStyle}"
+                                                 AllowDrop="True"
+                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                 Drop="TrackLocomotives_Drop">
+                                            <ListBox.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Horizontal"/>
+                                                </ItemsPanelTemplate>
+                                            </ListBox.ItemsPanel>
+                                            <ListBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                            PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
+                                                        <Grid>
+                                                            <Grid.RowDefinitions>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+                                                            </Grid.RowDefinitions>
+                                                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                       HorizontalAlignment="Left"/>
+                                                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                       HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ListBox.ItemTemplate>
+                                        </ListBox>
+                                        <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding ElementName=GarageMainList, Path=HasItems}" Value="False">
+                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </Grid>
+                                </StackPanel>
+                                <ItemsControl ItemsSource="{Binding ZoneTracks}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                                <StackPanel>
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                                            <TextBlock Text="{Binding LeftLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding LeftLabel}" Value="{x:Null}">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding LeftLabel}" Value="">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                            <Button Style="{StaticResource LeftBlockedSwitchStyle}"
+                                                                    Click="ToggleLeftBlocked_Click"/>
+                                                        </StackPanel>
+                                                        <Grid Grid.Column="1">
+                                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="6,0,0,0" VerticalAlignment="Center">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                                <StackPanel.Style>
+                                                                    <Style TargetType="StackPanel">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </StackPanel.Style>
+                                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="0,0,6,0"/>
+                                                                <Menu VerticalAlignment="Center">
+                                                                    <MenuItem Header="...">
+                                                                        <MenuItem Header="Renommer zone" Click="RenameZone_Click" Tag="{Binding}"/>
+                                                                        <MenuItem Header="Supprimer zone" Click="RemoveZone_Click" Tag="{Binding}"/>
+                                                                    </MenuItem>
+                                                                </Menu>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                        <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                            <Button Style="{StaticResource RightBlockedSwitchStyle}"
+                                                                    Click="ToggleRightBlocked_Click"/>
+                                                            <TextBlock Text="{Binding RightLabel}" FontWeight="SemiBold" Foreground="SlateGray">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding RightLabel}" Value="{x:Null}">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding RightLabel}" Value="">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                            <Menu HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                                <Menu.Style>
+                                                                    <Style TargetType="Menu">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding Name}" Value="917">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </Menu.Style>
+                                                                <MenuItem Header="...">
+                                                                    <MenuItem Header="Renommer zone" Click="RenameZone_Click" Tag="{Binding}"/>
+                                                                    <MenuItem Header="Supprimer zone" Click="RemoveZone_Click" Tag="{Binding}"/>
+                                                                </MenuItem>
+                                                            </Menu>
+                                                        </StackPanel>
+                                                    </Grid>
+                                                    <Grid>
+                                                        <ListBox x:Name="GarageZoneList"
+                                                                 ItemsSource="{Binding Locomotives}"
+                                                                 Style="{StaticResource DropListBoxStyle}"
+                                                                 AllowDrop="True"
+                                                                 PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                                 PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                                 Drop="TrackLocomotives_Drop">
+                                                            <ListBox.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                    <Canvas />
+                                                                </ItemsPanelTemplate>
+                                                            </ListBox.ItemsPanel>
+                                                            <ListBox.ItemContainerStyle>
+                                                                <Style TargetType="ListBoxItem">
+                                                                    <Setter Property="Canvas.Left" Value="{Binding AssignedTrackOffsetX, TargetNullValue=0}"/>
+                                                                    <Setter Property="Canvas.Top" Value="0"/>
+                                                                </Style>
+                                                            </ListBox.ItemContainerStyle>
+                                                            <ListBox.ItemTemplate>
+                                                                <DataTemplate>
+                                                                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                            Padding="4" Margin="2" CornerRadius="4"
+                                                                            ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                                            PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
+                                                                        <Grid>
+                                                                            <Grid.RowDefinitions>
+                                                                                <RowDefinition Height="Auto"/>
+                                                                                <RowDefinition Height="Auto"/>
+                                                                            </Grid.RowDefinitions>
+                                                                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                       HorizontalAlignment="Left"/>
+                                                                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                       HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                                <TextBlock.Style>
+                                                                                    <Style TargetType="TextBlock">
+                                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                                        <Style.Triggers>
+                                                                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                            </DataTrigger>
+                                                                                        </Style.Triggers>
+                                                                                    </Style>
+                                                                                </TextBlock.Style>
+                                                                            </TextBlock>
+                                                                        </Grid>
+                                                                    </Border>
+                                                                </DataTemplate>
+                                                            </ListBox.ItemTemplate>
+                                                        </ListBox>
+                                                        <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                                   HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding ElementName=GarageZoneList, Path=HasItems}" Value="False">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                    </Grid>
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </StackPanel>
+                    <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                           Cursor="SizeNWSE" DragDelta="TileResizeThumb_DragDelta" DragCompleted="TileResizeThumb_DragCompleted"
+                           Background="#55000000" BorderBrush="#FF7A7A7A" BorderThickness="1"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="LineTileTemplate">
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="180"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <Grid>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                            <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                <MenuItem Header="...">
+                                    <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Ajouter voie" Click="AddLineTrack_Click" Tag="{Binding}"/>
+                                </MenuItem>
+                            </Menu>
+                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding LineTracks}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                            <StackPanel>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold"/>
+                                                    <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                                        <MenuItem Header="...">
+                                                            <MenuItem Header="Renommer voie" Click="RenameLineTrack_Click" Tag="{Binding}"/>
+                                                            <MenuItem Header="Supprimer voie" Click="RemoveLineTrack_Click" Tag="{Binding}"/>
+                                                        </MenuItem>
+                                                    </Menu>
+                                                </Grid>
+                                                <TextBlock Text="{Binding LineInfo}" FontSize="11" Foreground="SlateGray" Margin="0,2,0,4"/>
+                                                <Grid>
+                                                    <ListBox x:Name="LineTrackList"
+                                                             ItemsSource="{Binding Locomotives}"
+                                                             Style="{StaticResource DropListBoxStyle}"
+                                                             AllowDrop="True"
+                                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                             Drop="TrackLocomotives_Drop">
+                                                        <ListBox.ItemsPanel>
+                                                            <ItemsPanelTemplate>
+                                                                <Canvas />
+                                                            </ItemsPanelTemplate>
+                                                        </ListBox.ItemsPanel>
+                                                        <ListBox.ItemContainerStyle>
+                                                            <Style TargetType="ListBoxItem">
+                                                                <Setter Property="Canvas.Left" Value="{Binding AssignedTrackOffsetX, TargetNullValue=0}"/>
+                                                                <Setter Property="Canvas.Top" Value="0"/>
+                                                            </Style>
+                                                        </ListBox.ItemContainerStyle>
+                                                        <ListBox.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                        Padding="4" Margin="2" CornerRadius="4"
+                                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                                        PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
+                                                                    <Grid>
+                                                                        <Grid.RowDefinitions>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                        </Grid.RowDefinitions>
+                                                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                   HorizontalAlignment="Left"/>
+                                                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                            <TextBlock.Style>
+                                                                                <Style TargetType="TextBlock">
+                                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                                    <Style.Triggers>
+                                                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                        </DataTrigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </TextBlock.Style>
+                                                                        </TextBlock>
+                                                                    </Grid>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ListBox.ItemTemplate>
+                                                    </ListBox>
+                                                    <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding ElementName=LineTrackList, Path=HasItems}" Value="False">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Grid>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </StackPanel>
+                    <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                           Cursor="SizeNWSE" DragDelta="TileResizeThumb_DragDelta" DragCompleted="TileResizeThumb_DragCompleted"
+                           Background="#55000000" BorderBrush="#FF7A7A7A" BorderThickness="1"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="RollingLineTileTemplate">
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="220"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <Grid>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                            <Button Grid.Column="1" Content="Ajouter une ligne" Margin="6,0,6,0" Click="AddRollingLine_Click"/>
+                            <Menu Grid.Column="2" HorizontalAlignment="Right">
+                                <MenuItem Header="...">
+                                    <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                </MenuItem>
+                            </Menu>
+                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding RollingLines}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,0">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Grid.Column="0" Text="{Binding Number}" FontWeight="SemiBold" Margin="0,0,8,0"/>
+                                                <Grid Grid.Column="1">
+                                                    <ListBox x:Name="RollingLineList"
+                                                             ItemsSource="{Binding Locomotives}"
+                                                             Style="{StaticResource DropListBoxStyle}"
+                                                             AllowDrop="True"
+                                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                             Drop="RollingLineLocomotives_Drop">
+                                                        <ListBox.ItemsPanel>
+                                                            <ItemsPanelTemplate>
+                                                                <WrapPanel Orientation="Horizontal"/>
+                                                            </ItemsPanelTemplate>
+                                                        </ListBox.ItemsPanel>
+                                                        <ListBox.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                        Padding="4" Margin="2" CornerRadius="4"
+                                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                                        PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
+                                                                    <Grid>
+                                                                        <Grid.RowDefinitions>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                        </Grid.RowDefinitions>
+                                                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                   HorizontalAlignment="Left"/>
+                                                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                            <TextBlock.Style>
+                                                                                <Style TargetType="TextBlock">
+                                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                                    <Style.Triggers>
+                                                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                        </DataTrigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </TextBlock.Style>
+                                                                        </TextBlock>
+                                                                    </Grid>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ListBox.ItemTemplate>
+                                                    </ListBox>
+                                                    <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding ElementName=RollingLineList, Path=HasItems}" Value="False">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Grid>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </StackPanel>
+                    <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                           Cursor="SizeNWSE" DragDelta="TileResizeThumb_DragDelta" DragCompleted="TileResizeThumb_DragCompleted"
+                           Background="#55000000" BorderBrush="#FF7A7A7A" BorderThickness="1"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        <helpers:TileTemplateSelector x:Key="TileTemplateSelector"
+                                    DepotTemplate="{StaticResource DepotTileTemplate}"
+                                    GarageTemplate="{StaticResource GarageTileTemplate}"
+                                    LineTemplate="{StaticResource LineTileTemplate}"
+                                    RollingLineTemplate="{StaticResource RollingLineTileTemplate}"/>
     </Window.Resources>
     <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="Fichier">
+                <MenuItem Header="Sauvegarder" Click="MenuItem_Save_Click"/>
+                <MenuItem Header="Charger" Click="MenuItem_Load_Click"/>
+            </MenuItem>
+            <MenuItem Header="Gestion">
+                <MenuItem Header="Gestion des parcs" Click="MenuItem_PoolManagement_Click"/>
+                <MenuItem Header="Historique" Click="MenuItem_History_Click"/>
+            </MenuItem>
+            <MenuItem Header="Tapis">
+                <MenuItem Header="T13" Click="MenuItem_TapisT13_Click"/>
+                <MenuItem Header="37000" IsEnabled="False"/>
+            </MenuItem>
+            <MenuItem Header="Vue">
+                <MenuItem Header="Charger un preset" x:Name="ViewPresetsMenu"/>
+                <MenuItem Header="Enregistrer le preset..." Click="SaveLayoutPreset_Click"/>
+                <MenuItem Header="Supprimer un preset" x:Name="ViewPresetsDeleteMenu"/>
+            </MenuItem>
+            <MenuItem Header="Option">
+                <MenuItem Header="Mode sombre" IsCheckable="True" Click="ToggleDarkMode_Click"/>
+                <MenuItem Header="Gestion base de données" Click="MenuItem_DatabaseManagement_Click"/>
+                <MenuItem Header="Réinitialiser">
+                    <MenuItem Header="Réinitialiser locomotives" Click="MenuItem_ResetLocomotives_Click"/>
+                    <MenuItem Header="Réinitialiser tuiles" Click="MenuItem_ResetTiles_Click"/>
+                </MenuItem>
+            </MenuItem>
+        </Menu>
         <ToolBar DockPanel.Dock="Top">
-            <Button Content="Ajouter dépôt" Click="AddDepot_Click"/>
-            <Button Content="Ajouter arrêt en ligne" Click="AddLineStop_Click"/>
-            <Button Content="Ajouter voie de garage" Click="AddGarage_Click"/>
+            <Button Content="Ajouter un lieu" Click="AddPlace_Click"/>
         </ToolBar>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="260"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <Border Grid.Column="0" Margin="10" Background="#FFEFF4FF" CornerRadius="6">
+            <Border Grid.Column="0" Margin="10" Background="{DynamicResource PanelBackgroundBrush}" CornerRadius="6">
                 <DockPanel>
                     <TextBlock DockPanel.Dock="Top" Text="Locomotives" FontWeight="Bold" Margin="8"/>
-                    <ListBox x:Name="LocomotiveList"
-                             DisplayMemberPath="DisplayName"
-                             PreviewMouseLeftButtonDown="LocomotiveList_PreviewMouseLeftButtonDown"
-                             PreviewMouseMove="LocomotiveList_PreviewMouseMove"/>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ListBox x:Name="LocomotiveList"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                 ScrollViewer.CanContentScroll="False"
+                                 AllowDrop="True"
+                                 Drop="LocomotiveList_Drop"
+                                 PreviewMouseLeftButtonDown="LocomotiveList_PreviewMouseLeftButtonDown"
+                                 PreviewMouseMove="LocomotiveList_PreviewMouseMove">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Visibility"
+                                        Value="{Binding IsVisibleInActivePool, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                        Padding="6" Margin="4" CornerRadius="4"
+                                        ContextMenu="{StaticResource LocomotiveListContextMenu}"
+                                        PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                   HorizontalAlignment="Left"/>
+                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                        </ListBox>
+                    </ScrollViewer>
                 </DockPanel>
             </Border>
-            <Border Grid.Column="1" Margin="10" Background="#FFF7F7F7" CornerRadius="6">
+            <Border Grid.Column="1" Margin="10" Background="{DynamicResource CanvasBackgroundBrush}" CornerRadius="6">
                 <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                     <ItemsControl x:Name="TileCanvas">
                         <ItemsControl.ItemsPanel>
@@ -53,69 +911,7 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Background="White" BorderBrush="#FFB0B0B0" BorderThickness="1"
-                                        CornerRadius="6" Padding="8" Width="340"
-                                        AllowDrop="True"
-                                        Drop="Tile_Drop"
-                                        MouseLeftButtonDown="Tile_MouseLeftButtonDown"
-                                        MouseMove="Tile_MouseMove"
-                                        MouseLeftButtonUp="Tile_MouseLeftButtonUp">
-                                    <StackPanel>
-                                        <DockPanel>
-                                            <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="14"/>
-                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                                                <Button Style="{StaticResource TileHeaderButton}" Content="Renommer"
-                                                        Click="RenameTile_Click" Tag="{Binding}"/>
-                                                <Button Style="{StaticResource TileHeaderButton}" Content="Configurer"
-                                                        Click="ConfigureTile_Click" Tag="{Binding}"/>
-                                                <Button Style="{StaticResource TileHeaderButton}" Content="Supprimer"
-                                                        Click="DeleteTile_Click" Tag="{Binding}"/>
-                                            </StackPanel>
-                                        </DockPanel>
-                                        <TextBlock Text="{Binding Type}" Foreground="Gray" FontSize="12" Margin="0,2,0,2"/>
-                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
-                                            <TextBlock Text="{Binding LocationPreset}" Foreground="SlateGray" FontSize="11"/>
-                                            <TextBlock Text="{Binding GarageTrackNumber, StringFormat= Voie {0}, TargetNullValue='', FallbackValue=''}"
-                                                       Foreground="SlateGray" FontSize="11" Margin="6,0,0,0"/>
-                                        </StackPanel>
-                                        <ItemsControl ItemsSource="{Binding Tracks}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,0,0,6">
-                                                        <StackPanel>
-                                                            <DockPanel>
-                                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                                                                <Button DockPanel.Dock="Right" Style="{StaticResource TileHeaderButton}"
-                                                                        Content="Retirer voie" Click="RemoveTrack_Click"
-                                                                        Tag="{Binding}"/>
-                                                            </DockPanel>
-                                                            <ListBox ItemsSource="{Binding Locomotives}"
-                                                                     DisplayMemberPath="DisplayName"
-                                                                     AllowDrop="True"
-                                                                     PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                                                     PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                                                     Drop="TrackLocomotives_Drop">
-                                                                <ListBox.ItemTemplate>
-                                                                    <DataTemplate>
-                                                                        <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
-                                                                                Padding="4" Margin="2" CornerRadius="4"
-                                                                                ContextMenu="{StaticResource LocomotiveContextMenu}">
-                                                                            <TextBlock Text="{Binding DisplayName}" Foreground="White" FontWeight="Bold"/>
-                                                                        </Border>
-                                                                    </DataTemplate>
-                                                                </ListBox.ItemTemplate>
-                                                            </ListBox>
-                                                        </StackPanel>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                        <Button Content="Ajouter voie" Margin="0,4,0,0" Click="AddTrack_Click" Tag="{Binding}"/>
-                                        <Border Background="#FFF1F5FF" Padding="4" Margin="0,6,0,0" CornerRadius="4">
-                                            <TextBlock Text="Faites glisser les locomotives depuis la liste vers une voie." FontSize="11"/>
-                                        </Border>
-                                    </StackPanel>
-                                </Border>
+                                <ContentControl Content="{Binding}" ContentTemplateSelector="{StaticResource TileTemplateSelector}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -1,30 +1,46 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using Microsoft.Win32;
 using Ploco.Data;
 using Ploco.Dialogs;
+using Ploco.Helpers;
 using Ploco.Models;
 
 namespace Ploco
 {
     public partial class MainWindow : Window
     {
+        public static readonly RoutedUICommand LocomotiveHsCommand = new("Loc HS", "LocomotiveHsCommand", typeof(MainWindow));
         private readonly PlocoRepository _repository;
         private readonly ObservableCollection<LocomotiveModel> _locomotives = new();
         private readonly ObservableCollection<TileModel> _tiles = new();
+        private readonly List<LayoutPreset> _layoutPresets = new();
+        private const string LayoutPresetFileName = "layout_presets.json";
+        private const double MinTileWidth = 260;
+        private const double MinTileHeight = 180;
+        private bool _isDarkMode;
         private Point _dragStartPoint;
         private TileModel? _draggedTile;
         private Point _tileDragStart;
-
+        private bool _isResizingTile;
+        private readonly Dictionary<Type, Window> _modelessWindows = new();
         public MainWindow()
         {
             InitializeComponent();
             _repository = new PlocoRepository("ploco.db");
+            InputBindings.Add(new KeyBinding(LocomotiveHsCommand, new KeyGesture(Key.H, ModifierKeys.Control)));
+            CommandBindings.Add(new CommandBinding(LocomotiveHsCommand, LocomotiveHsCommand_Executed, LocomotiveHsCommand_CanExecute));
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
@@ -33,12 +49,23 @@ namespace Ploco
             _repository.SeedDefaultDataIfNeeded();
 
             LoadState();
+            LoadLayoutPresets();
+            RefreshPresetMenu();
+            ApplyTheme(false);
             LocomotiveList.ItemsSource = _locomotives;
             TileCanvas.ItemsSource = _tiles;
+            InitializeLocomotiveView();
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
+            var result = MessageBox.Show("Êtes-vous sûr de vouloir quitter ?", "Quitter", MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (result != MessageBoxResult.Yes)
+            {
+                e.Cancel = true;
+                return;
+            }
+
             PersistState();
         }
 
@@ -55,12 +82,16 @@ namespace Ploco
 
             foreach (var tile in state.Tiles)
             {
-                if (!tile.Tracks.Any())
+                EnsureDefaultTracks(tile);
+                EnsureRollingLines(tile);
+                foreach (var track in tile.Tracks)
                 {
-                    tile.Tracks.Add(CreateDefaultTrack(tile));
+                    EnsureTrackOffsets(track);
                 }
                 _tiles.Add(tile);
             }
+
+            UpdatePoolVisibility();
         }
 
         private void PersistState()
@@ -72,6 +103,13 @@ namespace Ploco
                 Tiles = _tiles.ToList()
             };
             _repository.SaveState(state);
+        }
+
+        private void InitializeLocomotiveView()
+        {
+            var view = CollectionViewSource.GetDefaultView(_locomotives);
+            view.SortDescriptions.Clear();
+            view.SortDescriptions.Add(new System.ComponentModel.SortDescription(nameof(LocomotiveModel.Number), System.ComponentModel.ListSortDirection.Ascending));
         }
 
         private List<RollingStockSeries> BuildSeriesState()
@@ -101,122 +139,419 @@ namespace Ploco
         {
             return tile.Type switch
             {
-                TileType.Depot => new TrackModel { Name = "Sortie 1" },
-                TileType.VoieGarage => new TrackModel { Name = "Voie 1" },
-                _ => new TrackModel { Name = "Locomotives" }
+                TileType.Depot => new TrackModel { Name = "Locomotives", Kind = TrackKind.Main },
+                TileType.VoieGarage => new TrackModel { Name = "Vrac", Kind = TrackKind.Main },
+                _ => new TrackModel { Name = "Locomotives", Kind = TrackKind.Main }
             };
         }
 
-        private void AddDepot_Click(object sender, RoutedEventArgs e)
+        private void AddPlace_Click(object sender, RoutedEventArgs e)
         {
-            AddTile(TileType.Depot, "Dépôt");
+            var dialog = new PlaceDialog { Owner = this };
+            if (dialog.ShowDialog() == true)
+            {
+                if (dialog.SelectedType == TileType.ArretLigne)
+                {
+                    var lineDialog = new LinePlaceDialog(dialog.SelectedName) { Owner = this };
+                    if (lineDialog.ShowDialog() == true)
+                    {
+                        AddLineTile(lineDialog);
+                    }
+                    return;
+                }
+
+                if (dialog.SelectedType == TileType.LigneRoulement)
+                {
+                    AddRollingLineTile(dialog.SelectedName);
+                    return;
+                }
+
+                AddTile(dialog.SelectedType, dialog.SelectedName);
+            }
         }
 
-        private void AddLineStop_Click(object sender, RoutedEventArgs e)
-        {
-            AddTile(TileType.ArretLigne, "Arrêt en ligne");
-        }
-
-        private void AddGarage_Click(object sender, RoutedEventArgs e)
-        {
-            AddTile(TileType.VoieGarage, "Voie de garage");
-        }
-
-        private void AddTile(TileType type, string defaultName)
+        private void AddTile(TileType type, string name)
         {
             var tile = new TileModel
             {
-                Name = defaultName,
+                Name = name,
                 Type = type,
                 X = 20 + _tiles.Count * 30,
-                Y = 20 + _tiles.Count * 30,
-                LocationPreset = type == TileType.VoieGarage ? "Garage A" : null,
-                GarageTrackNumber = type == TileType.VoieGarage ? 1 : null
+                Y = 20 + _tiles.Count * 30
             };
-            tile.Tracks.Add(CreateDefaultTrack(tile));
+            EnsureDefaultTracks(tile);
+            ApplyGaragePresets(tile);
             _tiles.Add(tile);
-            _repository.AddHistory("TileCreated", $"Création de la tuile {tile.Name} ({tile.Type}).");
+            _repository.AddHistory("TileCreated", $"Création du lieu {tile.DisplayTitle}.");
+            PersistState();
+        }
+
+        private void AddLineTile(LinePlaceDialog dialog)
+        {
+            var tile = new TileModel
+            {
+                Name = dialog.PlaceName,
+                Type = TileType.ArretLigne,
+                X = 20 + _tiles.Count * 30,
+                Y = 20 + _tiles.Count * 30
+            };
+
+            var track = new TrackModel
+            {
+                Name = dialog.TrackName,
+                Kind = TrackKind.Line,
+                IsOnTrain = dialog.IsOnTrain,
+                TrainNumber = dialog.IsOnTrain ? dialog.TrainNumber : null,
+                StopTime = dialog.IsOnTrain ? dialog.StopTime : null,
+                IssueReason = dialog.IssueReason,
+                IsLocomotiveHs = dialog.IsLocomotiveHs
+            };
+
+            tile.Tracks.Add(track);
+            tile.RefreshTrackCollections();
+            _tiles.Add(tile);
+            _repository.AddHistory("TileCreated", $"Création du lieu {tile.DisplayTitle}.");
+            _repository.AddHistory("LineTrackAdded", $"Ajout de la voie {track.Name} dans {tile.DisplayTitle}.");
+
+            var missingLocos = new List<string>();
+            var unavailableLocos = new List<string>();
+            var invalidLocos = new List<string>();
+            var locomotiveNumbers = ParseLocomotiveNumbers(dialog.LocomotiveNumbers, invalidLocos);
+            foreach (var number in locomotiveNumbers)
+            {
+                var loco = _locomotives.FirstOrDefault(l => l.Number == number);
+                if (loco == null)
+                {
+                    missingLocos.Add(number.ToString());
+                    continue;
+                }
+
+                if (loco.AssignedTrackId != null)
+                {
+                    unavailableLocos.Add(number.ToString());
+                    continue;
+                }
+
+                MoveLocomotiveToTrack(loco, track, track.Locomotives.Count);
+            }
+
+            var missingHsLocos = new List<string>();
+            var invalidHsLocos = new List<string>();
+            if (dialog.IsLocomotiveHs)
+            {
+                var hsNumbers = ParseLocomotiveNumbers(dialog.HsLocomotiveNumbers, invalidHsLocos);
+                foreach (var number in hsNumbers)
+                {
+                    var loco = _locomotives.FirstOrDefault(l => l.Number == number);
+                    if (loco == null)
+                    {
+                        missingHsLocos.Add(number.ToString());
+                        continue;
+                    }
+
+                    if (loco.Status != LocomotiveStatus.HS)
+                    {
+                        loco.Status = LocomotiveStatus.HS;
+                        _repository.AddHistory("StatusChanged", $"Statut modifié pour {loco.Number} (HS).");
+                    }
+                }
+            }
+
+            if (invalidLocos.Any() || invalidHsLocos.Any())
+            {
+                MessageBox.Show($"Numéros invalides ignorés : {string.Join(", ", invalidLocos.Concat(invalidHsLocos))}.",
+                    "Information", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+
+            if (missingLocos.Any() || missingHsLocos.Any())
+            {
+                var missingMessage = new List<string>();
+                if (missingLocos.Any())
+                {
+                    missingMessage.Add($"Locomotives introuvables pour l'ajout : {string.Join(", ", missingLocos)}.");
+                }
+                if (missingHsLocos.Any())
+                {
+                    missingMessage.Add($"Locomotives introuvables pour HS : {string.Join(", ", missingHsLocos)}.");
+                }
+                MessageBox.Show(string.Join(Environment.NewLine, missingMessage), "Information", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+
+            if (unavailableLocos.Any())
+            {
+                MessageBox.Show($"Locomotives déjà affectées ignorées : {string.Join(", ", unavailableLocos)}.",
+                    "Information", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+
+            UpdatePoolVisibility();
+            PersistState();
+        }
+
+        private void AddRollingLineTile(string name)
+        {
+            var tile = new TileModel
+            {
+                Name = string.IsNullOrWhiteSpace(name) ? "Ligne de roulement" : name,
+                Type = TileType.LigneRoulement,
+                X = 20 + _tiles.Count * 30,
+                Y = 20 + _tiles.Count * 30
+            };
+            EnsureRollingLines(tile);
+            _tiles.Add(tile);
+            _repository.AddHistory("TileCreated", $"Création du lieu {tile.DisplayTitle}.");
             PersistState();
         }
 
         private void DeleteTile_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button button && button.Tag is TileModel tile)
+            var tile = GetTileFromSender(sender);
+            if (tile == null)
             {
-                foreach (var track in tile.Tracks)
-                {
-                    foreach (var loco in track.Locomotives.ToList())
-                    {
-                        loco.AssignedTrackId = null;
-                    }
-                }
-                _tiles.Remove(tile);
-                _repository.AddHistory("TileDeleted", $"Suppression de la tuile {tile.Name}.");
-                PersistState();
+                return;
             }
+
+            foreach (var track in tile.Tracks.ToList())
+            {
+                foreach (var loco in track.Locomotives.ToList())
+                {
+                    track.Locomotives.Remove(loco);
+                    loco.AssignedTrackId = null;
+                }
+            }
+            foreach (var line in tile.RollingLines.ToList())
+            {
+                foreach (var loco in line.Locomotives.ToList())
+                {
+                    line.Locomotives.Remove(loco);
+                    loco.AssignedRollingLineId = null;
+                }
+            }
+            _tiles.Remove(tile);
+            _repository.AddHistory("TileDeleted", $"Suppression du lieu {tile.DisplayTitle}.");
+            UpdatePoolVisibility();
+            PersistState();
         }
 
         private void RenameTile_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button button && button.Tag is TileModel tile)
+            var tile = GetTileFromSender(sender);
+            if (tile == null)
             {
-                var dialog = new SimpleTextDialog("Renommer la tuile", "Nom :", tile.Name) { Owner = this };
-                if (dialog.ShowDialog() == true)
-                {
-                    tile.Name = dialog.ResponseText;
-                    _repository.AddHistory("TileRenamed", $"Tuile renommée en {tile.Name}.");
-                    PersistState();
-                }
+                return;
             }
-        }
 
-        private void ConfigureTile_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is Button button && button.Tag is TileModel tile)
+            var dialog = new SimpleTextDialog("Renommer la tuile", "Nom :", tile.Name) { Owner = this };
+            if (dialog.ShowDialog() == true)
             {
-                var dialog = new TileConfigDialog(tile) { Owner = this };
-                if (dialog.ShowDialog() == true)
-                {
-                    _repository.AddHistory("TileConfigured", $"Configuration mise à jour pour {tile.Name}.");
-                    PersistState();
-                }
-            }
-        }
-
-        private void AddTrack_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is Button button && button.Tag is TileModel tile)
-            {
-                var trackName = tile.Type switch
-                {
-                    TileType.Depot => $"Sortie {tile.Tracks.Count + 1}",
-                    TileType.VoieGarage => $"Voie {tile.Tracks.Count + 1}",
-                    _ => $"Zone {tile.Tracks.Count + 1}"
-                };
-                tile.Tracks.Add(new TrackModel { Name = trackName });
-                _repository.AddHistory("TrackAdded", $"Ajout de {trackName} dans {tile.Name}.");
+                tile.Name = dialog.ResponseText;
+                _repository.AddHistory("TileRenamed", $"Tuile renommée en {tile.Name}.");
                 PersistState();
             }
         }
 
-        private void RemoveTrack_Click(object sender, RoutedEventArgs e)
+        private void AddDepotOutput_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button button && button.Tag is TrackModel track)
+            var tile = GetTileFromSender(sender);
+            if (tile == null)
+            {
+                return;
+            }
+
+            if (tile.OutputTracks.Any())
+            {
+                MessageBox.Show("Une seule voie de sortie est autorisée.", "Action impossible", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var track = new TrackModel
+            {
+                Name = "Voie de sortie",
+                Kind = TrackKind.Output
+            };
+            tile.Tracks.Add(track);
+            tile.RefreshTrackCollections();
+            _repository.AddHistory("TrackAdded", $"Ajout de la voie de sortie dans {tile.DisplayTitle}.");
+            PersistState();
+        }
+
+        private void AddGarageZone_Click(object sender, RoutedEventArgs e)
+        {
+            var tile = GetTileFromSender(sender);
+            if (tile == null)
+            {
+                return;
+            }
+
+            var dialog = new SimpleTextDialog("Ajouter une zone", "Nom de zone :", "Zone 1") { Owner = this };
+            if (dialog.ShowDialog() == true)
+            {
+                var track = new TrackModel
+                {
+                    Name = dialog.ResponseText,
+                    Kind = TrackKind.Zone
+                };
+                tile.Tracks.Add(track);
+                tile.RefreshTrackCollections();
+                _repository.AddHistory("ZoneAdded", $"Ajout de la zone {track.Name} dans {tile.DisplayTitle}.");
+                PersistState();
+            }
+        }
+
+        private void RenameZone_Click(object sender, RoutedEventArgs e)
+        {
+            var track = GetTrackFromSender(sender);
+            if (track != null)
+            {
+                var dialog = new SimpleTextDialog("Renommer la zone", "Nom de zone :", track.Name) { Owner = this };
+                if (dialog.ShowDialog() == true)
+                {
+                    track.Name = dialog.ResponseText;
+                    _repository.AddHistory("ZoneRenamed", $"Zone renommée en {track.Name}.");
+                    PersistState();
+                }
+            }
+        }
+
+        private void RemoveZone_Click(object sender, RoutedEventArgs e)
+        {
+            var track = GetTrackFromSender(sender);
+            if (track != null)
             {
                 var tile = _tiles.FirstOrDefault(t => t.Tracks.Contains(track));
-                if (tile == null || tile.Tracks.Count <= 1)
+                if (tile == null)
                 {
-                    MessageBox.Show("Une tuile doit conserver au moins une voie.", "Action impossible", MessageBoxButton.OK, MessageBoxImage.Warning);
                     return;
                 }
 
                 foreach (var loco in track.Locomotives.ToList())
                 {
+                    track.Locomotives.Remove(loco);
                     loco.AssignedTrackId = null;
                 }
 
                 tile.Tracks.Remove(track);
-                _repository.AddHistory("TrackRemoved", $"Suppression de {track.Name} dans {tile.Name}.");
+                tile.RefreshTrackCollections();
+                _repository.AddHistory("ZoneRemoved", $"Suppression de la zone {track.Name} dans {tile.DisplayTitle}.");
+                UpdatePoolVisibility();
+                PersistState();
+            }
+        }
+
+        private void AddLineTrack_Click(object sender, RoutedEventArgs e)
+        {
+            var tile = GetTileFromSender(sender);
+            if (tile == null)
+            {
+                return;
+            }
+
+            var dialog = new LineTrackDialog { Owner = this };
+            if (dialog.ShowDialog() == true)
+            {
+                var track = dialog.BuildTrack();
+                track.Kind = TrackKind.Line;
+                tile.Tracks.Add(track);
+                tile.RefreshTrackCollections();
+                _repository.AddHistory("LineTrackAdded", $"Ajout de la voie {track.Name} dans {tile.DisplayTitle}.");
+                PersistState();
+            }
+        }
+
+        private void AddRollingLine_Click(object sender, RoutedEventArgs e)
+        {
+            var tile = GetTileFromSender(sender);
+            if (tile == null || tile.Type != TileType.LigneRoulement)
+            {
+                return;
+            }
+
+            var nextNumber = tile.RollingLines.Any() ? tile.RollingLines.Max(line => line.Number) + 1 : 1101;
+            var dialog = new SimpleTextDialog("Ajouter une ligne", "Numéro de ligne :", nextNumber.ToString()) { Owner = this };
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            if (!int.TryParse(dialog.ResponseText, out var lineNumber))
+            {
+                MessageBox.Show("Veuillez saisir un numéro valide.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (tile.RollingLines.Any(line => line.Number == lineNumber))
+            {
+                MessageBox.Show("Ce numéro de ligne existe déjà.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var newLine = new RollingLineModel
+            {
+                Number = lineNumber
+            };
+            var insertIndex = tile.RollingLines.TakeWhile(line => line.Number < lineNumber).Count();
+            tile.RollingLines.Insert(insertIndex, newLine);
+            _repository.AddHistory("RollingLineAdded", $"Ajout de la ligne {lineNumber} dans {tile.DisplayTitle}.");
+            PersistState();
+        }
+
+        private void RemoveLineTrack_Click(object sender, RoutedEventArgs e)
+        {
+            var track = GetTrackFromSender(sender);
+            if (track != null)
+            {
+                var tile = _tiles.FirstOrDefault(t => t.Tracks.Contains(track));
+                if (tile == null)
+                {
+                    return;
+                }
+
+                foreach (var loco in track.Locomotives.ToList())
+                {
+                    track.Locomotives.Remove(loco);
+                    loco.AssignedTrackId = null;
+                }
+
+                tile.Tracks.Remove(track);
+                tile.RefreshTrackCollections();
+                _repository.AddHistory("LineTrackRemoved", $"Suppression de la voie {track.Name} dans {tile.DisplayTitle}.");
+                UpdatePoolVisibility();
+                PersistState();
+            }
+        }
+
+        private void RenameLineTrack_Click(object sender, RoutedEventArgs e)
+        {
+            var track = GetTrackFromSender(sender);
+            if (track == null)
+            {
+                return;
+            }
+
+            var dialog = new SimpleTextDialog("Renommer la voie", "Nom de voie :", track.Name) { Owner = this };
+            if (dialog.ShowDialog() == true)
+            {
+                track.Name = dialog.ResponseText;
+                _repository.AddHistory("LineTrackRenamed", $"Voie renommée en {track.Name}.");
+                PersistState();
+            }
+        }
+
+        private void ToggleLeftBlocked_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button button && button.DataContext is TrackModel track)
+            {
+                track.IsLeftBlocked = !track.IsLeftBlocked;
+                _repository.AddHistory("ZoneBlockedUpdated", $"Mise à jour du remplissage BLOCK pour {track.Name}.");
+                PersistState();
+            }
+        }
+
+        private void ToggleRightBlocked_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button button && button.DataContext is TrackModel track)
+            {
+                track.IsRightBlocked = !track.IsRightBlocked;
+                _repository.AddHistory("ZoneBlockedUpdated", $"Mise à jour du remplissage BIF pour {track.Name}.");
                 PersistState();
             }
         }
@@ -245,6 +580,35 @@ namespace Ploco
             {
                 DragDrop.DoDragDrop(LocomotiveList, loco, DragDropEffects.Move);
             }
+        }
+
+        private void LocomotiveList_Drop(object sender, DragEventArgs e)
+        {
+            if (!e.Data.GetDataPresent(typeof(LocomotiveModel)))
+            {
+                return;
+            }
+
+            var loco = (LocomotiveModel)e.Data.GetData(typeof(LocomotiveModel))!;
+            var track = _tiles.SelectMany(t => t.Tracks).FirstOrDefault(t => t.Locomotives.Contains(loco));
+            if (track != null)
+            {
+                track.Locomotives.Remove(loco);
+                loco.AssignedTrackId = null;
+                loco.AssignedTrackOffsetX = null;
+                _repository.AddHistory("LocomotiveRemoved", $"Loco {loco.Number} retirée de {track.Name}.");
+            }
+            var rollingLine = GetRollingLineForLocomotive(loco);
+            if (rollingLine != null)
+            {
+                rollingLine.Locomotives.Remove(loco);
+                loco.AssignedRollingLineId = null;
+                _repository.AddHistory("LocomotiveRemoved", $"Loco {loco.Number} retirée de la ligne {rollingLine.Number}.");
+            }
+
+            UpdatePoolVisibility();
+            PersistState();
+            e.Handled = true;
         }
 
         private void TrackLocomotives_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -285,9 +649,40 @@ namespace Ploco
                 var loco = (LocomotiveModel)e.Data.GetData(typeof(LocomotiveModel))!;
                 var insertIndex = GetInsertIndex(listBox, e.GetPosition(listBox));
                 MoveLocomotiveToTrack(loco, track, insertIndex);
+                UpdateLocomotiveDropOffset(loco, track, listBox, e.GetPosition(listBox));
                 PersistState();
                 e.Handled = true;
             }
+        }
+
+        private void RollingLineLocomotives_Drop(object sender, DragEventArgs e)
+        {
+            if (sender is not ListBox listBox || listBox.DataContext is not RollingLineModel line)
+            {
+                return;
+            }
+
+            if (!e.Data.GetDataPresent(typeof(LocomotiveModel)))
+            {
+                return;
+            }
+
+            var loco = (LocomotiveModel)e.Data.GetData(typeof(LocomotiveModel))!;
+            if (line.Locomotives.Contains(loco))
+            {
+                return;
+            }
+
+            if (line.Locomotives.Count > 0)
+            {
+                MessageBox.Show("Cette ligne de roulement contient déjà une locomotive.", "Action impossible", MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            MoveLocomotiveToRollingLine(loco, line);
+            PersistState();
+            e.Handled = true;
         }
 
         private void Tile_Drop(object sender, DragEventArgs e)
@@ -300,11 +695,24 @@ namespace Ploco
             if (e.Data.GetDataPresent(typeof(LocomotiveModel)))
             {
                 var loco = (LocomotiveModel)e.Data.GetData(typeof(LocomotiveModel))!;
-                var targetTrack = tile.Tracks.FirstOrDefault();
+                var targetTrack = GetDefaultDropTrack(tile);
+                var targetLine = GetDefaultDropRollingLine(tile);
                 if (targetTrack != null)
                 {
                     MoveLocomotiveToTrack(loco, targetTrack, targetTrack.Locomotives.Count);
                     PersistState();
+                }
+                else if (targetLine != null)
+                {
+                    MoveLocomotiveToRollingLine(loco, targetLine);
+                    PersistState();
+                }
+                else
+                {
+                    var message = tile.Type == TileType.LigneRoulement
+                        ? "Aucune ligne de roulement disponible pour déposer une locomotive."
+                        : "Aucune voie disponible pour déposer une locomotive.";
+                    MessageBox.Show(message, "Action impossible", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
             }
         }
@@ -316,11 +724,13 @@ namespace Ploco
             {
                 var currentIndex = currentTrack.Locomotives.IndexOf(loco);
                 currentTrack.Locomotives.Remove(loco);
+                EnsureTrackOffsets(currentTrack);
                 if (currentTrack == targetTrack && insertIndex > currentIndex)
                 {
                     insertIndex--;
                 }
             }
+            RemoveLocomotiveFromRollingLine(loco);
 
             if (!targetTrack.Locomotives.Contains(loco))
             {
@@ -335,7 +745,116 @@ namespace Ploco
             }
 
             loco.AssignedTrackId = targetTrack.Id;
-            _repository.AddHistory("LocomotiveMoved", $"Loco {loco.DisplayName} déplacée vers {targetTrack.Name}.");
+            loco.AssignedTrackOffsetX = null;
+            loco.AssignedRollingLineId = null;
+            EnsureTrackOffsets(targetTrack);
+            _repository.AddHistory("LocomotiveMoved", $"Loco {loco.Number} déplacée vers {targetTrack.Name}.");
+            UpdatePoolVisibility();
+            RefreshTapisT13();
+        }
+
+        private void MoveLocomotiveToRollingLine(LocomotiveModel loco, RollingLineModel line)
+        {
+            var currentTrack = _tiles.SelectMany(t => t.Tracks).FirstOrDefault(t => t.Locomotives.Contains(loco));
+            if (currentTrack != null)
+            {
+                currentTrack.Locomotives.Remove(loco);
+                EnsureTrackOffsets(currentTrack);
+            }
+
+            RemoveLocomotiveFromRollingLine(loco);
+
+            if (!line.Locomotives.Contains(loco))
+            {
+                line.Locomotives.Add(loco);
+            }
+
+            loco.AssignedTrackId = null;
+            loco.AssignedTrackOffsetX = null;
+            loco.AssignedRollingLineId = line.Id;
+            _repository.AddHistory("LocomotiveMoved", $"Loco {loco.Number} déplacée vers la ligne {line.Number}.");
+            UpdatePoolVisibility();
+            RefreshTapisT13();
+        }
+
+        private RollingLineModel? GetRollingLineForLocomotive(LocomotiveModel loco)
+        {
+            return _tiles.SelectMany(t => t.RollingLines).FirstOrDefault(l => l.Locomotives.Contains(loco));
+        }
+
+        private void RemoveLocomotiveFromRollingLine(LocomotiveModel loco)
+        {
+            var currentLine = GetRollingLineForLocomotive(loco);
+            if (currentLine != null)
+            {
+                currentLine.Locomotives.Remove(loco);
+                loco.AssignedRollingLineId = null;
+            }
+        }
+
+        private void UpdateLocomotiveDropOffset(LocomotiveModel loco, TrackModel track, ListBox listBox, Point dropPosition)
+        {
+            if (track.Kind != TrackKind.Line && track.Kind != TrackKind.Zone && track.Kind != TrackKind.Output)
+            {
+                loco.AssignedTrackOffsetX = null;
+                return;
+            }
+
+            const double slotWidth = 44;
+            var maxX = Math.Max(0, listBox.ActualWidth - slotWidth);
+            var clampedX = Math.Max(0, Math.Min(dropPosition.X, maxX));
+            var desiredSlot = (int)Math.Round(clampedX / slotWidth);
+            var occupiedSlots = track.Locomotives
+                .Where(item => !ReferenceEquals(item, loco))
+                .Select(item => item.AssignedTrackOffsetX.HasValue ? (int)Math.Round(item.AssignedTrackOffsetX.Value / slotWidth) : -1)
+                .Where(slot => slot >= 0)
+                .ToHashSet();
+
+            var slot = desiredSlot;
+            while (occupiedSlots.Contains(slot))
+            {
+                slot++;
+            }
+
+            loco.AssignedTrackOffsetX = slot * slotWidth;
+            EnsureTrackOffsets(track);
+        }
+
+        private static void EnsureTrackOffsets(TrackModel track)
+        {
+            if (track.Kind != TrackKind.Line && track.Kind != TrackKind.Zone && track.Kind != TrackKind.Output)
+            {
+                foreach (var loco in track.Locomotives)
+                {
+                    loco.AssignedTrackOffsetX = null;
+                }
+                return;
+            }
+
+            const double slotWidth = 44;
+            var occupiedSlots = new HashSet<int>();
+            foreach (var loco in track.Locomotives)
+            {
+                if (loco.AssignedTrackOffsetX.HasValue)
+                {
+                    var slot = (int)Math.Round(loco.AssignedTrackOffsetX.Value / slotWidth);
+                    if (!occupiedSlots.Contains(slot))
+                    {
+                        occupiedSlots.Add(slot);
+                        loco.AssignedTrackOffsetX = slot * slotWidth;
+                        continue;
+                    }
+                }
+
+                var fallbackSlot = 0;
+                while (occupiedSlots.Contains(fallbackSlot))
+                {
+                    fallbackSlot++;
+                }
+
+                occupiedSlots.Add(fallbackSlot);
+                loco.AssignedTrackOffsetX = fallbackSlot * slotWidth;
+            }
         }
 
         private static int GetInsertIndex(ListBox listBox, Point dropPosition)
@@ -356,41 +875,235 @@ namespace Ploco
 
         private void MenuItem_ModifierStatut_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            var loco = GetLocomotiveFromMenuItem(sender);
+            if (loco == null)
             {
-                if (contextMenu.PlacementTarget is FrameworkElement element && element.DataContext is LocomotiveModel loco)
-                {
-                    var dialog = new StatusDialog(loco) { Owner = this };
-                    if (dialog.ShowDialog() == true)
-                    {
-                        _repository.AddHistory("StatusChanged", $"Statut modifié pour {loco.DisplayName}.");
-                        PersistState();
-                    }
-                }
+                return;
+            }
+
+            var dialog = new StatusDialog(loco) { Owner = this };
+            if (dialog.ShowDialog() == true)
+            {
+                _repository.AddHistory("StatusChanged", $"Statut modifié pour {loco.Number}.");
+                PersistState();
+                RefreshTapisT13();
+            }
+        }
+
+        private void MenuItem_SwapPool_Click(object sender, RoutedEventArgs e)
+        {
+            var loco = GetLocomotiveFromMenuItem(sender);
+            if (loco != null)
+            {
+                OpenSwapDialog(loco);
+            }
+        }
+
+        private void MenuItem_LocHs_Click(object sender, RoutedEventArgs e)
+        {
+            var loco = GetLocomotiveFromMenuItem(sender);
+            if (loco != null)
+            {
+                MarkLocomotiveHs(loco);
             }
         }
 
         private void MenuItem_RemoveFromTile_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            var loco = GetLocomotiveFromMenuItem(sender);
+            if (loco == null)
             {
-                if (contextMenu.PlacementTarget is FrameworkElement element && element.DataContext is LocomotiveModel loco)
+                return;
+            }
+
+            var track = _tiles.SelectMany(t => t.Tracks).FirstOrDefault(t => t.Locomotives.Contains(loco));
+            if (track != null)
+            {
+                track.Locomotives.Remove(loco);
+                loco.AssignedTrackId = null;
+                loco.AssignedTrackOffsetX = null;
+                _repository.AddHistory("LocomotiveRemoved", $"Loco {loco.Number} retirée de {track.Name}.");
+            }
+            var rollingLine = GetRollingLineForLocomotive(loco);
+            if (rollingLine != null)
+            {
+                rollingLine.Locomotives.Remove(loco);
+                loco.AssignedRollingLineId = null;
+                _repository.AddHistory("LocomotiveRemoved", $"Loco {loco.Number} retirée de la ligne {rollingLine.Number}.");
+            }
+
+            UpdatePoolVisibility();
+            PersistState();
+            RefreshTapisT13();
+        }
+
+        private void OpenSwapDialog(LocomotiveModel loco)
+        {
+            if (!string.Equals(loco.Pool, "Sibelit", StringComparison.OrdinalIgnoreCase))
+            {
+                MessageBox.Show("Le swap est réservé aux locomotives de la pool Sibelit.", "Swap", MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            var lineasCandidates = _locomotives
+                .Where(item => string.Equals(item.Pool, "Lineas", StringComparison.OrdinalIgnoreCase)
+                               && item.AssignedTrackId == null)
+                .OrderBy(item => item.Number)
+                .ToList();
+            if (!lineasCandidates.Any())
+            {
+                MessageBox.Show("Aucune locomotive Lineas disponible pour le swap.", "Swap", MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            var dialog = new SwapDialog(loco, new ObservableCollection<LocomotiveModel>(lineasCandidates))
+            {
+                Owner = this
+            };
+            if (dialog.ShowDialog() == true && dialog.SelectedLoco != null)
+            {
+                ApplySwap(loco, dialog.SelectedLoco);
+            }
+        }
+
+        private void ApplySwap(LocomotiveModel sibelitLoco, LocomotiveModel lineasLoco)
+        {
+            var track = _tiles.SelectMany(t => t.Tracks).FirstOrDefault(t => t.Locomotives.Contains(sibelitLoco));
+            var trackIndex = track?.Locomotives.IndexOf(sibelitLoco) ?? -1;
+            var trackOffset = sibelitLoco.AssignedTrackOffsetX;
+
+            if (track != null)
+            {
+                track.Locomotives.Remove(sibelitLoco);
+            }
+
+            sibelitLoco.AssignedTrackId = null;
+            sibelitLoco.AssignedTrackOffsetX = null;
+            sibelitLoco.Pool = "Lineas";
+
+            lineasLoco.Pool = "Sibelit";
+            if (track != null)
+            {
+                if (trackIndex >= 0 && trackIndex <= track.Locomotives.Count)
                 {
-                    var track = _tiles.SelectMany(t => t.Tracks).FirstOrDefault(t => t.Locomotives.Contains(loco));
-                    if (track != null)
-                    {
-                        track.Locomotives.Remove(loco);
-                        loco.AssignedTrackId = null;
-                        _repository.AddHistory("LocomotiveRemoved", $"Loco {loco.DisplayName} retirée de {track.Name}.");
-                        PersistState();
-                    }
+                    track.Locomotives.Insert(trackIndex, lineasLoco);
+                }
+                else
+                {
+                    track.Locomotives.Add(lineasLoco);
+                }
+                lineasLoco.AssignedTrackId = track.Id;
+                lineasLoco.AssignedTrackOffsetX = trackOffset;
+                EnsureTrackOffsets(track);
+            }
+            else
+            {
+                lineasLoco.AssignedTrackId = null;
+                lineasLoco.AssignedTrackOffsetX = null;
+            }
+
+            _repository.AddHistory("LocomotiveSwapped",
+                $"Swap Sibelit {sibelitLoco.Number} ↔ Lineas {lineasLoco.Number}.");
+            UpdatePoolVisibility();
+            PersistState();
+            RefreshTapisT13();
+        }
+
+        private static LocomotiveModel? GetLocomotiveFromMenuItem(object sender)
+        {
+            if (sender is not MenuItem menuItem)
+            {
+                return null;
+            }
+
+            if (menuItem.CommandParameter is LocomotiveModel parameter)
+            {
+                return parameter;
+            }
+
+            if (menuItem.DataContext is LocomotiveModel dataContext)
+            {
+                return dataContext;
+            }
+
+            var contextMenu = menuItem.Parent as ContextMenu
+                ?? ItemsControl.ItemsControlFromItemContainer(menuItem) as ContextMenu;
+            if (contextMenu?.PlacementTarget is FrameworkElement element && element.DataContext is LocomotiveModel loco)
+            {
+                return loco;
+            }
+
+            return null;
+        }
+
+        private void MarkLocomotiveHs(LocomotiveModel loco)
+        {
+            var dialog = new StatusDialog(loco, LocomotiveStatus.HS) { Owner = this };
+            if (dialog.ShowDialog() == true)
+            {
+                _repository.AddHistory("StatusChanged", $"Statut modifié pour {loco.Number} (HS).");
+                PersistState();
+                RefreshTapisT13();
+            }
+        }
+
+        private void LocomotiveHsCommand_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            var loco = GetFocusedLocomotive();
+            if (loco != null)
+            {
+                MarkLocomotiveHs(loco);
+            }
+        }
+
+        private void LocomotiveHsCommand_CanExecute(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = GetFocusedLocomotive() != null;
+        }
+
+        private LocomotiveModel? GetFocusedLocomotive()
+        {
+            if (Keyboard.FocusedElement is DependencyObject element)
+            {
+                var loco = GetLocomotiveFromElement(element);
+                if (loco != null)
+                {
+                    return loco;
                 }
             }
+
+            return LocomotiveList.SelectedItem as LocomotiveModel;
+        }
+
+        private static LocomotiveModel? GetLocomotiveFromElement(DependencyObject? element)
+        {
+            while (element != null)
+            {
+                if (element is FrameworkElement frameworkElement && frameworkElement.DataContext is LocomotiveModel loco)
+                {
+                    return loco;
+                }
+
+                element = VisualTreeHelper.GetParent(element);
+            }
+
+            return null;
         }
 
         private void Tile_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (e.OriginalSource is DependencyObject source && FindAncestor<Button>(source) != null)
+            if (e.OriginalSource is DependencyObject source
+                && (FindAncestor<Button>(source) != null
+                    || FindAncestor<MenuItem>(source) != null
+                    || FindAncestor<Menu>(source) != null
+                    || FindAncestor<Thumb>(source) != null))
+            {
+                return;
+            }
+
+            if (_isResizingTile)
             {
                 return;
             }
@@ -405,7 +1118,7 @@ namespace Ploco
 
         private void Tile_MouseMove(object sender, MouseEventArgs e)
         {
-            if (_draggedTile == null || e.LeftButton != MouseButtonState.Pressed)
+            if (_draggedTile == null || e.LeftButton != MouseButtonState.Pressed || _isResizingTile)
             {
                 return;
             }
@@ -421,6 +1134,7 @@ namespace Ploco
         {
             if (_draggedTile != null)
             {
+                ResolveTileOverlap(_draggedTile);
                 _repository.AddHistory("TileMoved", $"Tuile {_draggedTile.Name} déplacée.");
                 PersistState();
             }
@@ -429,6 +1143,27 @@ namespace Ploco
                 border.ReleaseMouseCapture();
             }
             _draggedTile = null;
+        }
+
+        private void TileResizeThumb_DragDelta(object sender, DragDeltaEventArgs e)
+        {
+            if (sender is Thumb thumb && thumb.DataContext is TileModel tile)
+            {
+                _isResizingTile = true;
+                tile.Width = Math.Max(MinTileWidth, tile.Width + e.HorizontalChange);
+                tile.Height = Math.Max(MinTileHeight, tile.Height + e.VerticalChange);
+            }
+        }
+
+        private void TileResizeThumb_DragCompleted(object sender, DragCompletedEventArgs e)
+        {
+            _isResizingTile = false;
+            if (sender is Thumb thumb && thumb.DataContext is TileModel tile)
+            {
+                ResolveTileOverlap(tile);
+                _repository.AddHistory("TileResized", $"Tuile {tile.Name} redimensionnée.");
+                PersistState();
+            }
         }
 
         private static T? FindAncestor<T>(DependencyObject child) where T : DependencyObject
@@ -442,6 +1177,748 @@ namespace Ploco
                 child = VisualTreeHelper.GetParent(child);
             }
             return null;
+        }
+
+        private void UpdatePoolVisibility()
+        {
+            foreach (var loco in _locomotives)
+            {
+                loco.IsVisibleInActivePool = string.Equals(loco.Pool, "Sibelit", StringComparison.OrdinalIgnoreCase)
+                                             && loco.AssignedTrackId == null
+                                             && loco.AssignedRollingLineId == null;
+            }
+
+            LocomotiveList.Items.Refresh();
+        }
+
+        private void MenuItem_Save_Click(object sender, RoutedEventArgs e)
+        {
+            PersistState();
+            var dialog = new SaveFileDialog
+            {
+                Filter = "Base de données Ploco (*.db)|*.db|Tous les fichiers (*.*)|*.*",
+                FileName = "ploco.db"
+            };
+            if (dialog.ShowDialog() == true)
+            {
+                _repository.CopyDatabaseTo(dialog.FileName);
+            }
+        }
+
+        private void MenuItem_Load_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new OpenFileDialog
+            {
+                Filter = "Base de données Ploco (*.db)|*.db|Tous les fichiers (*.*)|*.*"
+            };
+            if (dialog.ShowDialog() == true)
+            {
+                if (!_repository.ReplaceDatabaseWith(dialog.FileName))
+                {
+                    MessageBox.Show("Le fichier sélectionné n'est pas une base SQLite valide.", "Chargement", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
+                _repository.Initialize();
+                LoadState();
+            }
+        }
+
+        private void MenuItem_PoolManagement_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new PoolTransferWindow(_locomotives)
+            {
+                Owner = this
+            };
+            dialog.ShowDialog();
+            UpdatePoolVisibility();
+            PersistState();
+            RefreshTapisT13();
+        }
+
+        private void MenuItem_History_Click(object sender, RoutedEventArgs e)
+        {
+            var history = _repository.LoadHistory();
+            var dialog = new HistoriqueWindow(history) { Owner = this };
+            dialog.ShowDialog();
+        }
+
+        private void MenuItem_TapisT13_Click(object sender, RoutedEventArgs e)
+        {
+            OpenModelessWindow(() => new TapisT13Window(_locomotives, _tiles));
+        }
+
+        private void MenuItem_DatabaseManagement_Click(object sender, RoutedEventArgs e)
+        {
+            OpenModelessWindow(() => new DatabaseManagementWindow(_repository, _locomotives, _tiles));
+        }
+
+        private void MenuItem_ResetLocomotives_Click(object sender, RoutedEventArgs e)
+        {
+            var result = MessageBox.Show("Réinitialiser toutes les locomotives ?", "Réinitialisation des locomotives", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            foreach (var track in _tiles.SelectMany(tile => tile.Tracks))
+            {
+                track.Locomotives.Clear();
+            }
+            foreach (var line in _tiles.SelectMany(tile => tile.RollingLines))
+            {
+                line.Locomotives.Clear();
+            }
+
+            foreach (var loco in _locomotives)
+            {
+                loco.AssignedTrackId = null;
+                loco.AssignedTrackOffsetX = null;
+                loco.AssignedRollingLineId = null;
+                loco.Status = LocomotiveStatus.Ok;
+                loco.TractionPercent = null;
+                loco.HsReason = null;
+                loco.MaintenanceDate = null;
+                loco.Pool = "Lineas";
+            }
+
+            _repository.AddHistory("ResetLocomotives", "Réinitialisation des locomotives.");
+            UpdatePoolVisibility();
+            PersistState();
+            RefreshTapisT13();
+        }
+
+        private void MenuItem_ResetTiles_Click(object sender, RoutedEventArgs e)
+        {
+            var result = MessageBox.Show("Supprimer toutes les tuiles ?", "Réinitialisation des tuiles", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            foreach (var tile in _tiles.ToList())
+            {
+                foreach (var track in tile.Tracks)
+                {
+                    foreach (var loco in track.Locomotives.ToList())
+                    {
+                        track.Locomotives.Remove(loco);
+                        loco.AssignedTrackId = null;
+                        loco.AssignedTrackOffsetX = null;
+                    }
+                }
+                foreach (var line in tile.RollingLines)
+                {
+                    foreach (var loco in line.Locomotives.ToList())
+                    {
+                        line.Locomotives.Remove(loco);
+                        loco.AssignedRollingLineId = null;
+                    }
+                }
+            }
+
+            _tiles.Clear();
+            _repository.AddHistory("ResetTiles", "Suppression de toutes les tuiles.");
+            UpdatePoolVisibility();
+            PersistState();
+            RefreshTapisT13();
+        }
+
+        private void ToggleDarkMode_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem)
+            {
+                _isDarkMode = menuItem.IsChecked;
+                ApplyTheme(_isDarkMode);
+            }
+        }
+
+        private void OpenModelessWindow<TWindow>(Func<TWindow> factory) where TWindow : Window
+        {
+            var windowType = typeof(TWindow);
+            if (_modelessWindows.TryGetValue(windowType, out var existing) && existing.IsVisible)
+            {
+                if (existing is IRefreshableWindow refreshable)
+                {
+                    refreshable.RefreshData();
+                }
+
+                existing.Activate();
+                return;
+            }
+
+            var window = factory();
+            window.Owner = this;
+            window.Closed += (_, _) => _modelessWindows.Remove(windowType);
+            _modelessWindows[windowType] = window;
+
+            if (window is IRefreshableWindow newRefreshable)
+            {
+                newRefreshable.RefreshData();
+            }
+
+            window.Show();
+            window.Activate();
+        }
+
+        private void RefreshTapisT13()
+        {
+            if (_modelessWindows.TryGetValue(typeof(TapisT13Window), out var window)
+                && window is IRefreshableWindow refreshable
+                && window.IsVisible)
+            {
+                refreshable.RefreshData();
+            }
+        }
+
+        private void LocomotiveItem_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is not FrameworkElement element)
+            {
+                return;
+            }
+
+            var contextMenu = element.ContextMenu;
+            if (contextMenu == null)
+            {
+                return;
+            }
+
+            if (FindAncestor<ListBoxItem>(element) is ListBoxItem listBoxItem)
+            {
+                listBoxItem.IsSelected = true;
+            }
+
+            contextMenu.DataContext = element.DataContext;
+            contextMenu.PlacementTarget = element;
+            contextMenu.IsOpen = true;
+            e.Handled = true;
+        }
+
+        private void SaveLayoutPreset_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new SimpleTextDialog("Enregistrer un preset", "Nom du preset :", "Nouveau preset") { Owner = this };
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            var name = dialog.ResponseText.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                MessageBox.Show("Veuillez saisir un nom valide.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var preset = BuildLayoutPreset(name);
+            var existing = _layoutPresets.FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (existing != null)
+            {
+                _layoutPresets.Remove(existing);
+            }
+            _layoutPresets.Add(preset);
+            SaveLayoutPresets();
+            RefreshPresetMenu();
+            _repository.AddHistory("LayoutPresetSaved", $"Preset enregistré : {name}.");
+        }
+
+        private void LoadLayoutPreset_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not MenuItem menuItem || menuItem.Tag is not LayoutPreset preset)
+            {
+                return;
+            }
+
+            ApplyLayoutPreset(preset);
+            _repository.AddHistory("LayoutPresetLoaded", $"Preset chargé : {preset.Name}.");
+            UpdatePoolVisibility();
+            PersistState();
+        }
+
+        private void DeleteLayoutPreset_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not MenuItem menuItem || menuItem.Tag is not LayoutPreset preset)
+            {
+                return;
+            }
+
+            var result = MessageBox.Show($"Supprimer le preset \"{preset.Name}\" ?", "Supprimer preset",
+                MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            _layoutPresets.Remove(preset);
+            SaveLayoutPresets();
+            RefreshPresetMenu();
+            _repository.AddHistory("LayoutPresetDeleted", $"Preset supprimé : {preset.Name}.");
+        }
+
+        private TrackModel? GetDefaultDropTrack(TileModel tile)
+        {
+            if (tile.Type == TileType.ArretLigne)
+            {
+                return tile.LineTracks.FirstOrDefault();
+            }
+
+            return tile.MainTrack;
+        }
+
+        private RollingLineModel? GetDefaultDropRollingLine(TileModel tile)
+        {
+            if (tile.Type == TileType.LigneRoulement)
+            {
+                return tile.RollingLines.FirstOrDefault(line => line.Locomotives.Count == 0);
+            }
+
+            return null;
+        }
+
+        private void EnsureDefaultTracks(TileModel tile)
+        {
+            if (!tile.Tracks.Any() && tile.Type != TileType.ArretLigne && tile.Type != TileType.LigneRoulement)
+            {
+                tile.Tracks.Add(CreateDefaultTrack(tile));
+            }
+            tile.RefreshTrackCollections();
+        }
+
+        private void EnsureRollingLines(TileModel tile)
+        {
+            if (tile.Type != TileType.LigneRoulement)
+            {
+                return;
+            }
+
+            if (tile.RollingLines.Any())
+            {
+                return;
+            }
+
+            for (var number = 1101; number <= 1123; number++)
+            {
+                tile.RollingLines.Add(new RollingLineModel
+                {
+                    Number = number
+                });
+            }
+        }
+
+        private void ApplyGaragePresets(TileModel tile)
+        {
+            if (tile.Type != TileType.VoieGarage)
+            {
+                return;
+            }
+
+            if (string.Equals(tile.Name, "Zeebrugge", StringComparison.OrdinalIgnoreCase))
+            {
+                RemoveMainTrack(tile);
+                AddGarageZone(tile, "BRAM");
+                AddGarageZone(tile, "ZWAN");
+            }
+
+            if (string.Equals(tile.Name, "Anvers Nord", StringComparison.OrdinalIgnoreCase))
+            {
+                RemoveMainTrack(tile);
+                var blockTrack = new TrackModel
+                {
+                    Name = "917",
+                    Kind = TrackKind.Zone,
+                    LeftLabel = "BLOCK",
+                    RightLabel = "BIF"
+                };
+                tile.Tracks.Add(blockTrack);
+                tile.RefreshTrackCollections();
+            }
+        }
+
+        private void AddGarageZone(TileModel tile, string name)
+        {
+            var track = new TrackModel
+            {
+                Name = name,
+                Kind = TrackKind.Zone
+            };
+            tile.Tracks.Add(track);
+            tile.RefreshTrackCollections();
+        }
+
+        private static void RemoveMainTrack(TileModel tile)
+        {
+            var main = tile.MainTrack;
+            if (main != null)
+            {
+                tile.Tracks.Remove(main);
+                tile.RefreshTrackCollections();
+            }
+        }
+
+        private static TrackModel? GetTrackFromSender(object sender)
+        {
+            if (sender is FrameworkElement element)
+            {
+                if (element.Tag is TrackModel trackFromTag)
+                {
+                    return trackFromTag;
+                }
+
+                if (element.DataContext is TrackModel trackFromContext)
+                {
+                    return trackFromContext;
+                }
+            }
+
+            return null;
+        }
+
+        private TileModel? GetTileFromSender(object sender)
+        {
+            if (sender is FrameworkElement element)
+            {
+                if (element.Tag is TileModel tileFromTag)
+                {
+                    return tileFromTag;
+                }
+
+                if (element.DataContext is TileModel tileFromContext)
+                {
+                    return tileFromContext;
+                }
+            }
+
+            return null;
+        }
+
+        private void ResolveTileOverlap(TileModel tile)
+        {
+            const double step = 20;
+
+            var hasOverlap = true;
+            while (hasOverlap)
+            {
+                hasOverlap = false;
+                foreach (var other in _tiles)
+                {
+                    if (ReferenceEquals(other, tile))
+                    {
+                        continue;
+                    }
+
+                    if (IsOverlapping(tile, other))
+                    {
+                        tile.X += step;
+                        tile.Y += step;
+                        hasOverlap = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        private static bool IsOverlapping(TileModel first, TileModel second)
+        {
+            return first.X < second.X + second.Width
+                   && first.X + first.Width > second.X
+                   && first.Y < second.Y + second.Height
+                   && first.Y + first.Height > second.Y;
+        }
+
+        private static List<int> ParseLocomotiveNumbers(string input, List<string> invalidTokens)
+        {
+            var numbers = new List<int>();
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return numbers;
+            }
+
+            var tokens = input.Split(new[] { ' ', ',', ';', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var token in tokens)
+            {
+                if (int.TryParse(token, out var number))
+                {
+                    numbers.Add(number);
+                }
+                else
+                {
+                    invalidTokens.Add(token);
+                }
+            }
+
+            return numbers;
+        }
+
+        private void ApplyTheme(bool darkMode)
+        {
+            if (darkMode)
+            {
+                Resources["AppBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(34, 34, 34));
+                Resources["PanelBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(45, 45, 45));
+                Resources["CanvasBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(40, 40, 40));
+                Resources["TileBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(55, 55, 55));
+                Resources["TileBorderBrush"] = new SolidColorBrush(Color.FromRgb(90, 90, 90));
+                Resources["TrackBorderBrush"] = new SolidColorBrush(Color.FromRgb(80, 80, 80));
+                Resources["ListBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(50, 50, 50));
+                Resources["ListBorderBrush"] = new SolidColorBrush(Color.FromRgb(90, 90, 90));
+                Resources["AppForegroundBrush"] = new SolidColorBrush(Colors.WhiteSmoke);
+                Resources["MenuBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(45, 45, 45));
+                Resources["MenuBorderBrush"] = new SolidColorBrush(Color.FromRgb(70, 70, 70));
+                Resources["ToolBarBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(45, 45, 45));
+                Resources["ToolBarBorderBrush"] = new SolidColorBrush(Color.FromRgb(70, 70, 70));
+            }
+            else
+            {
+                Resources["AppBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
+                Resources["PanelBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(239, 244, 255));
+                Resources["CanvasBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(247, 247, 247));
+                Resources["TileBackgroundBrush"] = new SolidColorBrush(Colors.White);
+                Resources["TileBorderBrush"] = new SolidColorBrush(Color.FromRgb(176, 176, 176));
+                Resources["TrackBorderBrush"] = new SolidColorBrush(Color.FromRgb(224, 224, 224));
+                Resources["ListBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(245, 245, 245));
+                Resources["ListBorderBrush"] = new SolidColorBrush(Color.FromRgb(221, 221, 221));
+                Resources["AppForegroundBrush"] = new SolidColorBrush(Color.FromRgb(17, 17, 17));
+                Resources["MenuBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
+                Resources["MenuBorderBrush"] = new SolidColorBrush(Color.FromRgb(221, 221, 221));
+                Resources["ToolBarBackgroundBrush"] = new SolidColorBrush(Color.FromRgb(242, 242, 242));
+                Resources["ToolBarBorderBrush"] = new SolidColorBrush(Color.FromRgb(221, 221, 221));
+            }
+        }
+
+        private void LoadLayoutPresets()
+        {
+            _layoutPresets.Clear();
+            if (File.Exists(LayoutPresetFileName))
+            {
+                try
+                {
+                    var json = File.ReadAllText(LayoutPresetFileName);
+                    var presets = JsonSerializer.Deserialize<List<LayoutPreset>>(json, GetPresetSerializerOptions());
+                    if (presets != null)
+                    {
+                        _layoutPresets.AddRange(presets);
+                    }
+                }
+                catch (Exception)
+                {
+                    _layoutPresets.Clear();
+                }
+            }
+
+            if (_layoutPresets.All(p => !string.Equals(p.Name, "Défaut", StringComparison.OrdinalIgnoreCase)))
+            {
+                _layoutPresets.Add(BuildDefaultPreset());
+            }
+
+            SaveLayoutPresets();
+        }
+
+        private void SaveLayoutPresets()
+        {
+            var json = JsonSerializer.Serialize(_layoutPresets, GetPresetSerializerOptions());
+            File.WriteAllText(LayoutPresetFileName, json);
+        }
+
+        private void RefreshPresetMenu()
+        {
+            if (ViewPresetsMenu == null || ViewPresetsDeleteMenu == null)
+            {
+                return;
+            }
+
+            ViewPresetsMenu.Items.Clear();
+            ViewPresetsDeleteMenu.Items.Clear();
+            foreach (var preset in _layoutPresets.OrderBy(p => p.Name))
+            {
+                var item = new MenuItem
+                {
+                    Header = preset.Name,
+                    Tag = preset
+                };
+                item.Click += LoadLayoutPreset_Click;
+                ViewPresetsMenu.Items.Add(item);
+
+                if (!string.Equals(preset.Name, "Défaut", StringComparison.OrdinalIgnoreCase))
+                {
+                    var deleteItem = new MenuItem
+                    {
+                        Header = preset.Name,
+                        Tag = preset
+                    };
+                    deleteItem.Click += DeleteLayoutPreset_Click;
+                    ViewPresetsDeleteMenu.Items.Add(deleteItem);
+                }
+            }
+        }
+
+        private LayoutPreset BuildLayoutPreset(string name)
+        {
+            var tiles = _tiles
+                .Where(tile => tile.Type != TileType.ArretLigne && tile.Type != TileType.LigneRoulement)
+                .Select(tile => new LayoutTile
+                {
+                    Name = tile.Name,
+                    Type = tile.Type,
+                    X = tile.X,
+                    Y = tile.Y,
+                    Width = tile.Width,
+                    Height = tile.Height,
+                    Tracks = tile.Tracks.Select(track => new LayoutTrack
+                    {
+                        Name = track.Name,
+                        Kind = track.Kind,
+                        LeftLabel = track.LeftLabel,
+                        RightLabel = track.RightLabel,
+                        IsLeftBlocked = track.IsLeftBlocked,
+                        IsRightBlocked = track.IsRightBlocked
+                    }).ToList()
+                }).ToList();
+
+            return new LayoutPreset
+            {
+                Name = name,
+                Tiles = tiles
+            };
+        }
+
+        private LayoutPreset BuildDefaultPreset()
+        {
+            var preset = new LayoutPreset
+            {
+                Name = "Défaut",
+                Tiles = new List<LayoutTile>()
+            };
+
+            var defaultTiles = new List<(TileType type, string name)>
+            {
+                (TileType.Depot, "Thionville"),
+                (TileType.Depot, "Mulhouse Nord"),
+                (TileType.VoieGarage, "Zeebrugge"),
+                (TileType.VoieGarage, "Anvers Nord"),
+                (TileType.VoieGarage, "Bale")
+            };
+
+            const double startX = 20;
+            const double startY = 20;
+            const double stepX = 380;
+            const double stepY = 260;
+
+            for (var index = 0; index < defaultTiles.Count; index++)
+            {
+                var (type, name) = defaultTiles[index];
+                var tile = new TileModel
+                {
+                    Name = name,
+                    Type = type,
+                    X = startX + (index % 2) * stepX,
+                    Y = startY + (index / 2) * stepY
+                };
+                EnsureDefaultTracks(tile);
+                ApplyGaragePresets(tile);
+
+                preset.Tiles.Add(new LayoutTile
+                {
+                    Name = tile.Name,
+                    Type = tile.Type,
+                    X = tile.X,
+                    Y = tile.Y,
+                    Width = tile.Width,
+                    Height = tile.Height,
+                    Tracks = tile.Tracks.Select(track => new LayoutTrack
+                    {
+                        Name = track.Name,
+                        Kind = track.Kind,
+                        LeftLabel = track.LeftLabel,
+                        RightLabel = track.RightLabel,
+                        IsLeftBlocked = track.IsLeftBlocked,
+                        IsRightBlocked = track.IsRightBlocked
+                    }).ToList()
+                });
+            }
+
+            return preset;
+        }
+
+        private void ApplyLayoutPreset(LayoutPreset preset)
+        {
+            var removableTiles = _tiles.Where(tile => tile.Type != TileType.ArretLigne && tile.Type != TileType.LigneRoulement).ToList();
+            foreach (var tile in removableTiles)
+            {
+                foreach (var track in tile.Tracks)
+                {
+                    foreach (var loco in track.Locomotives.ToList())
+                    {
+                        track.Locomotives.Remove(loco);
+                        loco.AssignedTrackId = null;
+                        loco.AssignedTrackOffsetX = null;
+                    }
+                }
+                _tiles.Remove(tile);
+            }
+
+            foreach (var layoutTile in preset.Tiles.Where(t => t.Type != TileType.ArretLigne && t.Type != TileType.LigneRoulement))
+            {
+                var tile = new TileModel
+                {
+                    Name = layoutTile.Name,
+                    Type = layoutTile.Type,
+                    X = layoutTile.X,
+                    Y = layoutTile.Y,
+                    Width = layoutTile.Width > 0 ? layoutTile.Width : MinTileWidth,
+                    Height = layoutTile.Height > 0 ? layoutTile.Height : MinTileHeight
+                };
+                foreach (var layoutTrack in layoutTile.Tracks)
+                {
+                    tile.Tracks.Add(new TrackModel
+                    {
+                        Name = layoutTrack.Name,
+                        Kind = layoutTrack.Kind,
+                        LeftLabel = layoutTrack.LeftLabel,
+                        RightLabel = layoutTrack.RightLabel,
+                        IsLeftBlocked = layoutTrack.IsLeftBlocked,
+                        IsRightBlocked = layoutTrack.IsRightBlocked
+                    });
+                }
+                tile.RefreshTrackCollections();
+                _tiles.Add(tile);
+            }
+        }
+
+        private static JsonSerializerOptions GetPresetSerializerOptions()
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+            options.Converters.Add(new JsonStringEnumConverter());
+            return options;
+        }
+
+        private sealed class LayoutPreset
+        {
+            public string Name { get; set; } = string.Empty;
+            public List<LayoutTile> Tiles { get; set; } = new();
+        }
+
+        private sealed class LayoutTile
+        {
+            public string Name { get; set; } = string.Empty;
+            public TileType Type { get; set; }
+            public double X { get; set; }
+            public double Y { get; set; }
+            public double Width { get; set; }
+            public double Height { get; set; }
+            public List<LayoutTrack> Tracks { get; set; } = new();
+        }
+
+        private sealed class LayoutTrack
+        {
+            public string Name { get; set; } = string.Empty;
+            public TrackKind Kind { get; set; }
+            public string? LeftLabel { get; set; }
+            public string? RightLabel { get; set; }
+            public bool IsLeftBlocked { get; set; }
+            public bool IsRightBlocked { get; set; }
         }
     }
 }

--- a/Ploco/Models/RollingLineModel.cs
+++ b/Ploco/Models/RollingLineModel.cs
@@ -1,0 +1,36 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Ploco.Models
+{
+    public class RollingLineModel : INotifyPropertyChanged
+    {
+        private int _number;
+
+        public int Id { get; set; }
+        public int TileId { get; set; }
+
+        public int Number
+        {
+            get => _number;
+            set
+            {
+                if (_number != value)
+                {
+                    _number = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public ObservableCollection<LocomotiveModel> Locomotives { get; } = new();
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Ploco/Models/locot13.cs
+++ b/Ploco/Models/locot13.cs
@@ -15,11 +15,11 @@ namespace Ploco.Models
     {
         private bool _isOnCanvas;
         private StatutLocomotive _statut;
-        private string _currentPool;             // Propriété ajoutée pour le pool actuel
-        private string _defautMoteurDetails;
-        private string _emDetails;
-        private string _atevapDetails;
-        private string _modificationNotes;
+        private string _currentPool = string.Empty;             // Propriété ajoutée pour le pool actuel
+        private string _defautMoteurDetails = string.Empty;
+        private string _emDetails = string.Empty;
+        private string _atevapDetails = string.Empty;
+        private string _modificationNotes = string.Empty;
         private DateTime? _lastModificationDate;
 
         public int NumeroSerie { get; set; }

--- a/Ploco/ModifierStatutDialog.xaml.cs
+++ b/Ploco/ModifierStatutDialog.xaml.cs
@@ -51,9 +51,8 @@ namespace Ploco
         private void btnValider_Click(object sender, RoutedEventArgs e)
         {
             // Récupérer le nouveau statut depuis le ComboBox.
-            if (cbStatut.SelectedItem is ComboBoxItem selectedItem && selectedItem.Tag != null)
+            if (cbStatut.SelectedItem is ComboBoxItem selectedItem && selectedItem.Tag is string statutString && !string.IsNullOrWhiteSpace(statutString))
             {
-                string statutString = selectedItem.Tag.ToString();
                 if (Enum.TryParse(statutString, out StatutLocomotive statut))
                 {
                     NewStatut = statut;

--- a/Ploco/ParcLocoWindow.xaml
+++ b/Ploco/ParcLocoWindow.xaml
@@ -39,7 +39,7 @@
                         <Border Width="40" Height="30" Margin="5"
                                 Background="{Binding Statut, Converter={StaticResource StatutToBrushConverter}}"
                                 ContextMenu="{StaticResource LocomotivesContextMenu}">
-                            <TextBlock Text="{Binding NumeroSerie}" 
+                            <TextBlock Text="{Binding Number}" 
                                        Foreground="White" 
                                        VerticalAlignment="Center" 
                                        HorizontalAlignment="Center" 
@@ -63,7 +63,7 @@
                         <Border Width="40" Height="30" Margin="5"
                                 Background="{Binding Statut, Converter={StaticResource StatutToBrushConverter}}"
                                 ContextMenu="{StaticResource LocomotivesContextMenu}">
-                            <TextBlock Text="{Binding NumeroSerie}" 
+                            <TextBlock Text="{Binding Number}" 
                                        Foreground="White" 
                                        VerticalAlignment="Center" 
                                        HorizontalAlignment="Center" 

--- a/Ploco/ParcLocoWindow.xaml.cs
+++ b/Ploco/ParcLocoWindow.xaml.cs
@@ -9,10 +9,10 @@ namespace Ploco
 {
     public partial class ParcLocoWindow : Window
     {
-        public ObservableCollection<Locomotive> SibelitPool { get; set; }
-        public ObservableCollection<Locomotive> LineasPool { get; set; }
+        public ObservableCollection<LocomotiveModel> SibelitPool { get; set; }
+        public ObservableCollection<LocomotiveModel> LineasPool { get; set; }
 
-        public ParcLocoWindow(ObservableCollection<Locomotive> sibelitPool, ObservableCollection<Locomotive> lineasPool)
+        public ParcLocoWindow(ObservableCollection<LocomotiveModel> sibelitPool, ObservableCollection<LocomotiveModel> lineasPool)
         {
             InitializeComponent();
             Owner = Application.Current.MainWindow; // Définit la fenêtre principale comme propriétaire
@@ -23,9 +23,9 @@ namespace Ploco
             ItemsControlLineas.ItemsSource = LineasPool;
 
             CollectionView viewSibelit = (CollectionView)CollectionViewSource.GetDefaultView(SibelitPool);
-            viewSibelit.SortDescriptions.Add(new SortDescription("NumeroSerie", ListSortDirection.Ascending));
+            viewSibelit.SortDescriptions.Add(new SortDescription(nameof(LocomotiveModel.Number), ListSortDirection.Ascending));
             CollectionView viewLineas = (CollectionView)CollectionViewSource.GetDefaultView(LineasPool);
-            viewLineas.SortDescriptions.Add(new SortDescription("NumeroSerie", ListSortDirection.Ascending));
+            viewLineas.SortDescriptions.Add(new SortDescription(nameof(LocomotiveModel.Number), ListSortDirection.Ascending));
         }
 
         private void MenuItem_Swap_Click(object sender, RoutedEventArgs e)

--- a/Ploco/PoolTransferWindow.xaml
+++ b/Ploco/PoolTransferWindow.xaml
@@ -1,7 +1,11 @@
 ﻿<Window x:Class="Ploco.PoolTransferWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Ploco.Converters"
         Title="Gérer les Locomotives" Height="400" Width="600">
+    <Window.Resources>
+        <local:StatutToBrushConverter x:Key="StatutToBrushConverter"/>
+    </Window.Resources>
     <Grid Margin="10">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
@@ -14,13 +18,101 @@
         </Grid.RowDefinitions>
 
         <!-- Titres -->
-        <TextBlock Grid.Column="0" Text="Pool Sibelit" FontWeight="Bold" Margin="0,0,0,10"/>
-        <TextBlock Grid.Column="2" Text="Pool Lineas" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Right"/>
+        <StackPanel Grid.Column="0" Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock Text="Pool Sibelit" FontWeight="Bold"/>
+            <TextBlock x:Name="SibelitCountText" Foreground="SlateGray"/>
+        </StackPanel>
+        <StackPanel Grid.Column="2" Grid.Row="0" Margin="0,0,0,10" HorizontalAlignment="Right">
+            <TextBlock Text="Pool Lineas" FontWeight="Bold" HorizontalAlignment="Right"/>
+            <TextBlock x:Name="LineasCountText" Foreground="SlateGray" HorizontalAlignment="Right"/>
+        </StackPanel>
 
         <!-- ListBox pour Pool Sibelit -->
-        <ListBox x:Name="ListBoxSibelit" Grid.Column="0" Grid.Row="0" Margin="0,30,5,0" SelectionMode="Extended"/>
+        <ListBox x:Name="ListBoxSibelit"
+                 Grid.Column="0"
+                 Grid.Row="0"
+                 Margin="0,30,5,0"
+                 SelectionMode="Extended"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 ScrollViewer.CanContentScroll="False">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel/>
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                            CornerRadius="4" Padding="4" Margin="2">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                       HorizontalAlignment="Left"/>
+                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                       HorizontalAlignment="Right" Margin="0,2,0,0">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
         <!-- ListBox pour Pool Lineas -->
-        <ListBox x:Name="ListBoxLineas" Grid.Column="2" Grid.Row="0" Margin="5,30,0,0" SelectionMode="Extended"/>
+        <ListBox x:Name="ListBoxLineas"
+                 Grid.Column="2"
+                 Grid.Row="0"
+                 Margin="5,30,0,0"
+                 SelectionMode="Extended"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 ScrollViewer.CanContentScroll="False">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel/>
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                            CornerRadius="4" Padding="4" Margin="2">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                       HorizontalAlignment="Left"/>
+                            <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                       HorizontalAlignment="Right" Margin="0,2,0,0">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
 
         <!-- Boutons de transfert -->
         <StackPanel Grid.Column="1" Grid.Row="0" VerticalAlignment="Center">

--- a/Ploco/PoolTransferWindow.xaml.cs
+++ b/Ploco/PoolTransferWindow.xaml.cs
@@ -9,70 +9,83 @@ namespace Ploco
 {
     public partial class PoolTransferWindow : Window
     {
-        public ObservableCollection<Locomotive> LineasPool { get; set; }
-        public ObservableCollection<Locomotive> SibelitPool { get; set; }
+        private readonly ObservableCollection<LocomotiveModel> _locomotives;
+        private readonly CollectionViewSource _lineasSource;
+        private readonly CollectionViewSource _sibelitSource;
 
-        public PoolTransferWindow(ObservableCollection<Locomotive> lineasPool, ObservableCollection<Locomotive> sibelitPool)
+        public PoolTransferWindow(ObservableCollection<LocomotiveModel> locomotives)
         {
             InitializeComponent();
             Owner = Application.Current.MainWindow; // Définit la fenêtre principale comme propriétaire
             WindowStartupLocation = WindowStartupLocation.CenterOwner; // Centre la fenêtre sur la principale
 
-            LineasPool = lineasPool;
-            SibelitPool = sibelitPool;
+            _locomotives = locomotives;
 
-            ListBoxLineas.ItemsSource = LineasPool;
-            ListBoxSibelit.ItemsSource = SibelitPool;
-            ListBoxLineas.Items.Refresh();
-            ListBoxSibelit.Items.Refresh();
+            _lineasSource = new CollectionViewSource { Source = _locomotives };
+            _lineasSource.SortDescriptions.Add(new SortDescription(nameof(LocomotiveModel.Number), ListSortDirection.Ascending));
+            _lineasSource.Filter += (_, args) =>
+            {
+                if (args.Item is LocomotiveModel loco)
+                {
+                    args.Accepted = string.Equals(loco.Pool, "Lineas");
+                }
+            };
 
-            CollectionView viewLineas = (CollectionView)CollectionViewSource.GetDefaultView(LineasPool);
-            viewLineas.SortDescriptions.Add(new SortDescription("NumeroSerie", ListSortDirection.Ascending));
-            CollectionView viewSibelit = (CollectionView)CollectionViewSource.GetDefaultView(SibelitPool);
-            viewSibelit.SortDescriptions.Add(new SortDescription("NumeroSerie", ListSortDirection.Ascending));
+            _sibelitSource = new CollectionViewSource { Source = _locomotives };
+            _sibelitSource.SortDescriptions.Add(new SortDescription(nameof(LocomotiveModel.Number), ListSortDirection.Ascending));
+            _sibelitSource.Filter += (_, args) =>
+            {
+                if (args.Item is LocomotiveModel loco)
+                {
+                    args.Accepted = string.Equals(loco.Pool, "Sibelit");
+                }
+            };
+
+            ListBoxLineas.ItemsSource = _lineasSource.View;
+            ListBoxSibelit.ItemsSource = _sibelitSource.View;
+            UpdateCounts();
         }
 
-        // Transfert de Sibelit vers Lineas : si la loco est sur le tapis, le transfert est refusé.
         private void BtnTransferToLineas_Click(object sender, RoutedEventArgs e)
         {
-            var selectedItems = ListBoxSibelit.SelectedItems.Cast<Locomotive>().ToList();
+            var selectedItems = ListBoxSibelit.SelectedItems.Cast<LocomotiveModel>().ToList();
             foreach (var loco in selectedItems)
             {
-                if (loco.IsOnCanvas)
-                {
-                    MessageBox.Show($"La loco {loco} est sur le tapis et ne peut être transférée.",
-                                    "Transfert impossible",
-                                    MessageBoxButton.OK,
-                                    MessageBoxImage.Warning);
-                }
-                else
-                {
-                    SibelitPool.Remove(loco);
-                    if (!LineasPool.Contains(loco))
-                        LineasPool.Add(loco);
-                    // Mise à jour du pool courant
-                    loco.CurrentPool = "Lineas";
-                }
+                loco.Pool = "Lineas";
             }
+
+            RefreshViews();
         }
 
-        // Transfert de Lineas vers Sibelit.
         private void BtnTransferToSibelit_Click(object sender, RoutedEventArgs e)
         {
-            var selectedItems = ListBoxLineas.SelectedItems.Cast<Locomotive>().ToList();
+            var selectedItems = ListBoxLineas.SelectedItems.Cast<LocomotiveModel>().ToList();
             foreach (var loco in selectedItems)
             {
-                LineasPool.Remove(loco);
-                if (!SibelitPool.Contains(loco))
-                    SibelitPool.Add(loco);
-                // Mise à jour du pool courant
-                loco.CurrentPool = "Sibelit";
+                loco.Pool = "Sibelit";
             }
+
+            RefreshViews();
         }
 
         private void BtnClose_Click(object sender, RoutedEventArgs e)
         {
-            this.Close();
+            DialogResult = true;
+        }
+
+        private void RefreshViews()
+        {
+            _lineasSource.View.Refresh();
+            _sibelitSource.View.Refresh();
+            UpdateCounts();
+        }
+
+        private void UpdateCounts()
+        {
+            var sibelitCount = _locomotives.Count(loco => string.Equals(loco.Pool, "Sibelit", System.StringComparison.OrdinalIgnoreCase));
+            var lineasCount = _locomotives.Count(loco => string.Equals(loco.Pool, "Lineas", System.StringComparison.OrdinalIgnoreCase));
+            SibelitCountText.Text = $"Nombre de locomotives : {sibelitCount}";
+            LineasCountText.Text = $"Nombre de locomotives : {lineasCount}";
         }
     }
 }

--- a/Ploco/SwapDialog.xaml.cs
+++ b/Ploco/SwapDialog.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Windows;
 using System.Windows.Data;
 using System.Linq;
@@ -10,11 +9,11 @@ namespace Ploco
 {
     public partial class SwapDialog : Window
     {
-        public Locomotive LocoFromSibelit { get; set; }
-        public ObservableCollection<Locomotive> LineasPool { get; set; }
-        public Locomotive SelectedLoco { get; set; }  // La loco sélectionnée dans le ComboBox
+        public LocomotiveModel LocoFromSibelit { get; }
+        public ObservableCollection<LocomotiveModel> LineasPool { get; }
+        public LocomotiveModel? SelectedLoco { get; private set; }
 
-        public SwapDialog(Locomotive locoFromSibelit, ObservableCollection<Locomotive> lineasPool)
+        public SwapDialog(LocomotiveModel locoFromSibelit, ObservableCollection<LocomotiveModel> lineasPool)
         {
             InitializeComponent();
             Owner = Application.Current.MainWindow; // Définit la fenêtre principale comme propriétaire
@@ -24,12 +23,13 @@ namespace Ploco
             LineasPool = lineasPool;
 
             // Afficher la loco de Sibelit dans un TextBlock pour information
-            tbLocoSibelit.Text = LocoFromSibelit.ToString();
+            tbLocoSibelit.Text = LocoFromSibelit.Number.ToString();
 
             // Remplir le ComboBox avec la pool Lineas et trier par NumeroSerie
             cbLineas.ItemsSource = LineasPool;
             CollectionView view = (CollectionView)CollectionViewSource.GetDefaultView(LineasPool);
-            view.SortDescriptions.Add(new SortDescription("NumeroSerie", ListSortDirection.Ascending));
+            view.SortDescriptions.Add(new System.ComponentModel.SortDescription(nameof(LocomotiveModel.Number), System.ComponentModel.ListSortDirection.Ascending));
+            cbLineas.DisplayMemberPath = nameof(LocomotiveModel.DisplayName);
 
             if (cbLineas.Items.Count > 0)
                 cbLineas.SelectedIndex = 0;
@@ -47,18 +47,7 @@ namespace Ploco
             }
 
             // La loco sélectionnée dans la pool Lineas est celle avec laquelle on souhaite effectuer le swap
-            SelectedLoco = cbLineas.SelectedItem as Locomotive;
-
-            // Archive les informations du swap dans un fichier log
-            string logEntry = $"Action: Swap, Loc Sibelit: {LocoFromSibelit}, Loc Lineas: {SelectedLoco}, Date: {tbDateTime.Text}, Message: {tbMessage.Text}";
-            try
-            {
-                System.IO.File.AppendAllText("SwapLog.txt", logEntry + Environment.NewLine);
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("Erreur lors de l'enregistrement du swap : " + ex.Message);
-            }
+            SelectedLoco = cbLineas.SelectedItem as LocomotiveModel;
 
             // Le swap effectif (mise à jour des pools et de CurrentPool) se fera dans le code appelant
             this.DialogResult = true;


### PR DESCRIPTION
### Motivation
- Introduire un nouveau type de tuile « Ligne de roulement » avec affectation d'une locomotive par ligne et enrichir l'affichage (Tapis T13, colonne Date entretien, style HS). 
- Permettre la persistance des nouvelles entités (lignes, assignations) et enrichir la gestion opérationnelle (état des locos, history, outils d'administration). 
- Résoudre un conflit/erreur de compilation causé par la double définition de l'enum `TrackKind` et faciliter les merges en sortant `RollingLineModel` dans son propre fichier.

### Description
- Déplace `RollingLineModel` dans `Ploco/Models/RollingLineModel.cs` et supprime la redéfinition conflictuelle dans `DomainModels.cs` pour régler l'erreur CS0101/CS0246. 
- Élargit `PlocoRepository` avec nouvelles tables (`rolling_lines`, `rolling_line_locomotives`, `places`, `history`), migrations de colonnes, helpers (load/save, history, counts, copy/replace DB, reset operational state) et sérialisation de configs de tuiles/voies. 
- Ajoute de nombreuses UI/dialogs/templates et helpers : `TapisT13Window`, `DatabaseManagementWindow`, `PlaceDialog`, `LinePlaceDialog`, `LineTrackDialog`, `TileTemplateSelector`, styles XAML et templates de tuiles (Depot/Garage/Line/RollingLine) et intégration drag&drop pour assignations et offsets sur voies. 
- Modifie les modèles (`LocomotiveModel`, `TrackModel`, `TileModel`, `HistoryEntry`) et `MainWindow` pour gérer les lignes de roulement, mouvements locos entre voies/lignes, swaps de pools, presets de layout, theming et rafraîchissements modeless (fenêtres réutilisables). 

### Testing
- Aucun test automatisé n'a été exécuté dans cet environnement d'intégration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2e45bb48833189cbd3223905debb)