### PR TITLE
Add “Ligne de roulement” tile type, rolling-line tracks and T13 enhancements

### DIFF
--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -175,6 +175,7 @@ namespace Ploco.Data
                         {
                             tile.LocationPreset = config.LocationPreset;
                             tile.GarageTrackNumber = config.GarageTrackNumber;
+                            tile.RollingLineCount = config.RollingLineCount;
                             if (config.Width.HasValue)
                             {
                                 tile.Width = config.Width.Value;
@@ -358,6 +359,7 @@ namespace Ploco.Data
                 {
                     LocationPreset = tile.LocationPreset,
                     GarageTrackNumber = tile.GarageTrackNumber,
+                    RollingLineCount = tile.RollingLineCount,
                     Width = tile.Width,
                     Height = tile.Height
                 });
@@ -673,6 +675,7 @@ namespace Ploco.Data
         {
             public string? LocationPreset { get; set; }
             public int? GarageTrackNumber { get; set; }
+            public int? RollingLineCount { get; set; }
             public double? Width { get; set; }
             public double? Height { get; set; }
         }

--- a/Ploco/Data/PlocoRepository.cs
+++ b/Ploco/Data/PlocoRepository.cs
@@ -42,6 +42,7 @@ namespace Ploco.Data
                     pool TEXT NOT NULL DEFAULT 'Lineas',
                     traction_percent INTEGER,
                     hs_reason TEXT,
+                    maintenance_date TEXT,
                     FOREIGN KEY(series_id) REFERENCES series(id)
                 );",
                 @"CREATE TABLE IF NOT EXISTS tiles (
@@ -94,6 +95,7 @@ namespace Ploco.Data
             EnsureColumn(connection, "locomotives", "pool", "TEXT NOT NULL DEFAULT 'Lineas'");
             EnsureColumn(connection, "locomotives", "traction_percent", "INTEGER");
             EnsureColumn(connection, "locomotives", "hs_reason", "TEXT");
+            EnsureColumn(connection, "locomotives", "maintenance_date", "TEXT");
             EnsureColumn(connection, "tracks", "type", "TEXT NOT NULL DEFAULT 'Main'");
             EnsureColumn(connection, "tracks", "config_json", "TEXT");
             EnsureColumn(connection, "track_locomotives", "offset_x", "REAL");
@@ -126,7 +128,7 @@ namespace Ploco.Data
 
             using (var command = connection.CreateCommand())
             {
-                command.CommandText = "SELECT id, series_id, number, status, pool, traction_percent, hs_reason FROM locomotives;";
+                command.CommandText = "SELECT id, series_id, number, status, pool, traction_percent, hs_reason, maintenance_date FROM locomotives;";
                 using var reader = command.ExecuteReader();
                 while (reader.Read())
                 {
@@ -143,7 +145,8 @@ namespace Ploco.Data
                         Status = status,
                         Pool = reader.IsDBNull(4) ? "Lineas" : reader.GetString(4),
                         TractionPercent = reader.IsDBNull(5) ? null : reader.GetInt32(5),
-                        HsReason = reader.IsDBNull(6) ? null : reader.GetString(6)
+                        HsReason = reader.IsDBNull(6) ? null : reader.GetString(6),
+                        MaintenanceDate = reader.IsDBNull(7) ? null : reader.GetString(7)
                     });
                 }
             }
@@ -331,13 +334,14 @@ namespace Ploco.Data
                     loco.SeriesId = newSeriesId;
                 }
                 using var command = connection.CreateCommand();
-                command.CommandText = "INSERT INTO locomotives (series_id, number, status, pool, traction_percent, hs_reason) VALUES ($seriesId, $number, $status, $pool, $traction, $reason);";
+                command.CommandText = "INSERT INTO locomotives (series_id, number, status, pool, traction_percent, hs_reason, maintenance_date) VALUES ($seriesId, $number, $status, $pool, $traction, $reason, $maintenance);";
                 command.Parameters.AddWithValue("$seriesId", loco.SeriesId);
                 command.Parameters.AddWithValue("$number", loco.Number);
                 command.Parameters.AddWithValue("$status", loco.Status.ToString());
                 command.Parameters.AddWithValue("$pool", loco.Pool);
                 command.Parameters.AddWithValue("$traction", (object?)loco.TractionPercent ?? DBNull.Value);
                 command.Parameters.AddWithValue("$reason", string.IsNullOrWhiteSpace(loco.HsReason) ? DBNull.Value : loco.HsReason);
+                command.Parameters.AddWithValue("$maintenance", string.IsNullOrWhiteSpace(loco.MaintenanceDate) ? DBNull.Value : loco.MaintenanceDate);
                 command.ExecuteNonQuery();
                 loco.Id = GetLastInsertRowId(connection);
             }

--- a/Ploco/Dialogs/PdfPlacementDialog.xaml
+++ b/Ploco/Dialogs/PdfPlacementDialog.xaml
@@ -1,0 +1,64 @@
+<Window x:Class="Ploco.Dialogs.PdfPlacementDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Modifier placement" Height="420" Width="420"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Statut" FontWeight="SemiBold"/>
+        <ComboBox x:Name="StatusCombo" Grid.Row="1" Margin="0,6,0,12">
+            <ComboBoxItem Content="OK" Tag="Ok"/>
+            <ComboBoxItem Content="Manque de traction" Tag="ManqueTraction"/>
+            <ComboBoxItem Content="HS" Tag="HS"/>
+        </ComboBox>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,12">
+            <StackPanel Width="120">
+                <TextBlock Text="Traction (%)" FontWeight="SemiBold"/>
+                <TextBox x:Name="TractionText" Margin="0,6,12,0"/>
+            </StackPanel>
+            <StackPanel Width="120">
+                <TextBlock Text="Moteurs HS" FontWeight="SemiBold"/>
+                <TextBox x:Name="MotorsHsText" Margin="0,6,0,0"/>
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel Grid.Row="3" Margin="0,0,0,12">
+            <TextBlock Text="Raison HS" FontWeight="SemiBold"/>
+            <TextBox x:Name="HsReasonText" Margin="0,6,0,0"/>
+        </StackPanel>
+
+        <CheckBox x:Name="OnTrainCheck" Grid.Row="4" Content="Sur train" Margin="0,0,0,8"/>
+
+        <Grid Grid.Row="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                <TextBlock Text="Train N°" FontWeight="SemiBold"/>
+                <TextBox x:Name="TrainNumberText" Margin="0,6,0,12"/>
+                <TextBlock Text="Heure d'arrêt" FontWeight="SemiBold"/>
+                <TextBox x:Name="TrainStopText" Margin="0,6,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1">
+                <TextBlock Text="Commentaire" FontWeight="SemiBold"/>
+                <TextBox x:Name="CommentText" Margin="0,6,0,0" AcceptsReturn="True" Height="120"/>
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Valider" Width="90" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="90" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/PdfPlacementDialog.xaml.cs
+++ b/Ploco/Dialogs/PdfPlacementDialog.xaml.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class PdfPlacementDialog : Window
+    {
+        private readonly PlanningPdfWindow.PdfPlacementViewModel _placement;
+
+        public PdfPlacementDialog(PlanningPdfWindow.PdfPlacementViewModel placement)
+        {
+            InitializeComponent();
+            _placement = placement;
+            StatusCombo.SelectedIndex = placement.Status switch
+            {
+                LocomotiveStatus.ManqueTraction => 1,
+                LocomotiveStatus.HS => 2,
+                _ => 0
+            };
+            TractionText.Text = placement.TractionPercent?.ToString() ?? string.Empty;
+            MotorsHsText.Text = placement.MotorsHsCount?.ToString() ?? string.Empty;
+            HsReasonText.Text = placement.HsReason ?? string.Empty;
+            OnTrainCheck.IsChecked = placement.OnTrain;
+            TrainNumberText.Text = placement.TrainNumber ?? string.Empty;
+            TrainStopText.Text = placement.TrainStopTime ?? string.Empty;
+            CommentText.Text = placement.Comment ?? string.Empty;
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            _placement.Status = StatusCombo.SelectedIndex switch
+            {
+                1 => LocomotiveStatus.ManqueTraction,
+                2 => LocomotiveStatus.HS,
+                _ => LocomotiveStatus.Ok
+            };
+
+            _placement.TractionPercent = int.TryParse(TractionText.Text, out var traction) ? traction : null;
+            _placement.MotorsHsCount = int.TryParse(MotorsHsText.Text, out var motors) ? motors : null;
+            _placement.HsReason = string.IsNullOrWhiteSpace(HsReasonText.Text) ? null : HsReasonText.Text.Trim();
+            _placement.OnTrain = OnTrainCheck.IsChecked == true;
+            _placement.TrainNumber = string.IsNullOrWhiteSpace(TrainNumberText.Text) ? null : TrainNumberText.Text.Trim();
+            _placement.TrainStopTime = string.IsNullOrWhiteSpace(TrainStopText.Text) ? null : TrainStopText.Text.Trim();
+            _placement.Comment = string.IsNullOrWhiteSpace(CommentText.Text) ? null : CommentText.Text.Trim();
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/PlaceDialog.xaml
+++ b/Ploco/Dialogs/PlaceDialog.xaml
@@ -9,6 +9,7 @@
             <ComboBoxItem Content="Dépôt" Tag="Depot"/>
             <ComboBoxItem Content="Garage" Tag="VoieGarage"/>
             <ComboBoxItem Content="En ligne" Tag="ArretLigne"/>
+            <ComboBoxItem Content="Ligne de roulement" Tag="RollingLine"/>
         </ComboBox>
 
         <StackPanel x:Name="DepotPanel" Visibility="Collapsed">

--- a/Ploco/Dialogs/PlaceDialog.xaml.cs
+++ b/Ploco/Dialogs/PlaceDialog.xaml.cs
@@ -64,6 +64,8 @@ namespace Ploco.Dialogs
                     break;
                 case TileType.ArretLigne:
                     break;
+                case TileType.RollingLine:
+                    break;
             }
         }
 
@@ -82,10 +84,11 @@ namespace Ploco.Dialogs
                 TileType.Depot => DepotNameCombo.SelectedItem as string ?? string.Empty,
                 TileType.VoieGarage => ResolveGarageName(),
                 TileType.ArretLigne => string.Empty,
+                TileType.RollingLine => "Ligne de roulement",
                 _ => string.Empty
             };
 
-            if (SelectedType != TileType.ArretLigne && string.IsNullOrWhiteSpace(SelectedName))
+            if (SelectedType != TileType.ArretLigne && SelectedType != TileType.RollingLine && string.IsNullOrWhiteSpace(SelectedName))
             {
                 MessageBox.Show("Veuillez saisir un nom valide.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml
@@ -12,6 +12,8 @@
             <Button Content="Mode Calibration" Margin="6,0,0,0" Click="ToggleCalibrationMode_Click" x:Name="CalibrationModeButton"/>
             <Button Content="+ Ligne horizontale" Margin="6,0,0,0" Click="AddHorizontalLine_Click" x:Name="AddHorizontalButton" IsEnabled="False"/>
             <Button Content="+ Ligne verticale" Margin="6,0,0,0" Click="AddVerticalLine_Click" x:Name="AddVerticalButton" IsEnabled="False"/>
+            <Button Content="Réinitialiser calibration" Margin="6,0,0,0" Click="ResetCalibration_Click" x:Name="ResetCalibrationButton" IsEnabled="False" Foreground="Red"/>
+            <Separator/>
             <Button Content="Sauvegarder calibration" Margin="6,0,0,0" Click="SaveCalibration_Click" x:Name="SaveCalibrationButton" IsEnabled="False"/>
             <Button Content="Charger calibration" Margin="6,0,0,0" Click="LoadCalibration_Click" x:Name="LoadCalibrationButton"/>
             <Separator/>
@@ -121,35 +123,58 @@
 
             <Border Grid.Column="1" BorderBrush="#FFDDDDDD" BorderThickness="1" Margin="8" Padding="8">
                 <StackPanel>
-                    <TextBlock Text="Calibration" FontWeight="Bold" Margin="0,0,0,8"/>
-                    <TextBlock Text="Page active" FontWeight="SemiBold"/>
-                    <TextBlock Text="{Binding Calibration.PageLabel}" Margin="0,4,0,8"/>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                        <StackPanel Width="120">
-                            <TextBlock Text="X départ (00:00)" FontWeight="SemiBold"/>
-                            <TextBox Text="{Binding Calibration.XStartText, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,8,0"/>
+                    <TextBlock Text="📊 Calibration" FontWeight="Bold" FontSize="14" Margin="0,0,0,8"/>
+                    
+                    <!-- Instructions -->
+                    <Border Background="#FFF8F8F8" Padding="8" Margin="0,0,0,12" CornerRadius="4">
+                        <StackPanel>
+                            <TextBlock Text="Instructions rapides :" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                            <TextBlock TextWrapping="Wrap" FontSize="11">
+                                1. Activez "Mode Calibration"<LineBreak/>
+                                2. Placez des lignes verticales (heures)<LineBreak/>
+                                3. Placez des lignes horizontales (roulements)<LineBreak/>
+                                4. Les locomotives suivront les lignes !
+                            </TextBlock>
                         </StackPanel>
-                        <StackPanel Width="120">
-                            <TextBlock Text="X fin (24:00)" FontWeight="SemiBold"/>
-                            <TextBox Text="{Binding Calibration.XEndText, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,0"/>
+                    </Border>
+                    
+                    <!-- Page info -->
+                    <TextBlock Text="📄 Page active" FontWeight="SemiBold" FontSize="12" Margin="0,0,0,4"/>
+                    <TextBlock Text="{Binding Calibration.PageLabel}" Margin="0,0,0,12" FontSize="13" FontWeight="Bold"/>
+                    
+                    <!-- Legacy calibration (kept for compatibility) -->
+                    <Expander Header="⚙️ Calibration manuelle (ancien système)" IsExpanded="False" Margin="0,0,0,8">
+                        <StackPanel Margin="0,8,0,0">
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                <StackPanel Width="120">
+                                    <TextBlock Text="X départ (00:00)" FontWeight="SemiBold" FontSize="10"/>
+                                    <TextBox Text="{Binding Calibration.XStartText, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,8,0"/>
+                                </StackPanel>
+                                <StackPanel Width="120">
+                                    <TextBlock Text="X fin (24:00)" FontWeight="SemiBold" FontSize="10"/>
+                                    <TextBox Text="{Binding Calibration.XEndText, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,0"/>
+                                </StackPanel>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                <Button Content="Appliquer" Width="90" Click="ApplyCalibration_Click" FontSize="10"/>
+                                <Button Content="Ajouter ligne" Width="110" Margin="8,0,0,0" Click="AddCalibrationRow_Click" FontSize="10"/>
+                                <Button Content="Supprimer ligne" Width="110" Margin="8,0,0,0" Click="RemoveCalibrationRow_Click" FontSize="10"/>
+                            </StackPanel>
+                            <DataGrid ItemsSource="{Binding Calibration.Rows}"
+                                      AutoGenerateColumns="False"
+                                      CanUserAddRows="False"
+                                      HeadersVisibility="Column"
+                                      Height="200"
+                                      FontSize="10">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Roulement" Binding="{Binding RoulementId}" Width="*"/>
+                                    <DataGridTextColumn Header="Y (PDF)" Binding="{Binding YCenter}" Width="*"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
                         </StackPanel>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                        <Button Content="Appliquer" Width="90" Click="ApplyCalibration_Click"/>
-                        <Button Content="Ajouter ligne" Width="110" Margin="8,0,0,0" Click="AddCalibrationRow_Click"/>
-                        <Button Content="Supprimer ligne" Width="110" Margin="8,0,0,0" Click="RemoveCalibrationRow_Click"/>
-                    </StackPanel>
-                    <DataGrid ItemsSource="{Binding Calibration.Rows}"
-                              AutoGenerateColumns="False"
-                              CanUserAddRows="False"
-                              HeadersVisibility="Column"
-                              Height="420">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Header="Roulement" Binding="{Binding RoulementId}" Width="*"/>
-                            <DataGridTextColumn Header="Y (PDF)" Binding="{Binding YCenter}" Width="*"/>
-                        </DataGrid.Columns>
-                    </DataGrid>
-                    <TextBlock Text="{Binding Calibration.HelpText}" Foreground="SlateGray" Margin="0,8,0,0" TextWrapping="Wrap"/>
+                    </Expander>
+                    
+                    <TextBlock Text="{Binding Calibration.HelpText}" Foreground="SlateGray" Margin="0,8,0,0" TextWrapping="Wrap" FontSize="11"/>
                 </StackPanel>
             </Border>
         </Grid>

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml
@@ -18,65 +18,106 @@
             <TextBlock x:Name="ZoomLabel" Text="100%" Width="60" VerticalAlignment="Center" HorizontalAlignment="Center"/>
         </ToolBar>
 
-        <ScrollViewer x:Name="PdfScrollViewer" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-            <ItemsControl x:Name="PdfPages">
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <StackPanel />
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Border BorderBrush="#FFDDDDDD" BorderThickness="1" Margin="8" Padding="8">
-                            <Grid>
-                                <Image Source="{Binding PageImage}" Stretch="Fill"
-                                       Width="{Binding PageWidth}" Height="{Binding PageHeight}"/>
-                                <Canvas Width="{Binding PageWidth}" Height="{Binding PageHeight}"
-                                        Background="Transparent"
-                                        AllowDrop="True"
-                                        Drop="Overlay_Drop"
-                                        DragOver="Overlay_DragOver"
-                                        MouseLeftButtonDown="Overlay_MouseLeftButtonDown"
-                                        MouseMove="Overlay_MouseMove"
-                                        MouseLeftButtonUp="Overlay_MouseLeftButtonUp">
-                                    <ItemsControl ItemsSource="{Binding Placements}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <Canvas />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                        <ItemsControl.ItemContainerStyle>
-                                            <Style TargetType="ContentPresenter">
-                                                <Setter Property="Canvas.Left" Value="{Binding X}" />
-                                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
-                                            </Style>
-                                        </ItemsControl.ItemContainerStyle>
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <Border Padding="4" CornerRadius="4" Background="{Binding StatusBrush}"
-                                                        BorderBrush="#FF333333" BorderThickness="1"
-                                                        PreviewMouseLeftButtonDown="Token_MouseLeftButtonDown"
-                                                        PreviewMouseMove="Token_MouseMove">
-                                                    <Border.ContextMenu>
-                                                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                                            <MenuItem Header="Modifier" Click="EditPlacement_Click"/>
-                                                            <MenuItem Header="Supprimer" Click="DeletePlacement_Click"/>
-                                                        </ContextMenu>
-                                                    </Border.ContextMenu>
-                                                    <StackPanel>
-                                                        <TextBlock Text="{Binding LocNumber}" FontWeight="Bold" Foreground="White"/>
-                                                        <TextBlock Text="{Binding BadgeText}" FontSize="10" Foreground="White"/>
-                                                    </StackPanel>
-                                                </Border>
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-                                </Canvas>
-                            </Grid>
-                        </Border>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </ScrollViewer>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="280"/>
+            </Grid.ColumnDefinitions>
+
+            <ScrollViewer x:Name="PdfScrollViewer" Grid.Column="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="PdfPages">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border BorderBrush="#FFDDDDDD" BorderThickness="1" Margin="8" Padding="8">
+                                <Grid>
+                                    <Image Source="{Binding PageImage}" Stretch="Fill"
+                                           Width="{Binding PageWidth}" Height="{Binding PageHeight}"/>
+                                    <Canvas Width="{Binding PageWidth}" Height="{Binding PageHeight}"
+                                            Background="Transparent"
+                                            AllowDrop="True"
+                                            Drop="Overlay_Drop"
+                                            DragOver="Overlay_DragOver"
+                                            MouseLeftButtonDown="Overlay_MouseLeftButtonDown"
+                                            MouseMove="Overlay_MouseMove"
+                                            MouseLeftButtonUp="Overlay_MouseLeftButtonUp">
+                                        <ItemsControl ItemsSource="{Binding Placements}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <Canvas />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemContainerStyle>
+                                                <Style TargetType="ContentPresenter">
+                                                    <Setter Property="Canvas.Left" Value="{Binding X}" />
+                                                    <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                                                </Style>
+                                            </ItemsControl.ItemContainerStyle>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Padding="4" CornerRadius="4" Background="{Binding StatusBrush}"
+                                                            BorderBrush="#FF333333" BorderThickness="1"
+                                                            PreviewMouseLeftButtonDown="Token_MouseLeftButtonDown"
+                                                            PreviewMouseMove="Token_MouseMove">
+                                                        <Border.ContextMenu>
+                                                            <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                                                <MenuItem Header="Modifier" Click="EditPlacement_Click"/>
+                                                                <MenuItem Header="Supprimer" Click="DeletePlacement_Click"/>
+                                                            </ContextMenu>
+                                                        </Border.ContextMenu>
+                                                        <StackPanel>
+                                                            <TextBlock Text="{Binding LocNumber}" FontWeight="Bold" Foreground="White"/>
+                                                            <TextBlock Text="{Binding BadgeText}" FontSize="10" Foreground="White"/>
+                                                        </StackPanel>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Canvas>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+
+            <Border Grid.Column="1" BorderBrush="#FFDDDDDD" BorderThickness="1" Margin="8" Padding="8">
+                <StackPanel>
+                    <TextBlock Text="Calibration" FontWeight="Bold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Page active" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Calibration.PageLabel}" Margin="0,4,0,8"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <StackPanel Width="120">
+                            <TextBlock Text="X départ (00:00)" FontWeight="SemiBold"/>
+                            <TextBox Text="{Binding Calibration.XStartText, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,8,0"/>
+                        </StackPanel>
+                        <StackPanel Width="120">
+                            <TextBlock Text="X fin (24:00)" FontWeight="SemiBold"/>
+                            <TextBox Text="{Binding Calibration.XEndText, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <Button Content="Appliquer" Width="90" Click="ApplyCalibration_Click"/>
+                        <Button Content="Ajouter ligne" Width="110" Margin="8,0,0,0" Click="AddCalibrationRow_Click"/>
+                        <Button Content="Supprimer ligne" Width="110" Margin="8,0,0,0" Click="RemoveCalibrationRow_Click"/>
+                    </StackPanel>
+                    <DataGrid ItemsSource="{Binding Calibration.Rows}"
+                              AutoGenerateColumns="False"
+                              CanUserAddRows="False"
+                              HeadersVisibility="Column"
+                              Height="420">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Roulement" Binding="{Binding RoulementId}" Width="*"/>
+                            <DataGridTextColumn Header="Y (PDF)" Binding="{Binding YCenter}" Width="*"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock Text="{Binding Calibration.HelpText}" Foreground="SlateGray" Margin="0,8,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
+        </Grid>
     </DockPanel>
 </Window>

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml
@@ -8,7 +8,12 @@
             <Button Content="Charger PDF" Click="LoadPdf_Click"/>
             <Button Content="Exporter PDF annoté" Margin="6,0,0,0" Click="ExportPdf_Click"/>
             <Button Content="Exporter CSV" Margin="6,0,0,0" Click="ExportCsv_Click"/>
-            <Button Content="Recalibrer" Margin="6,0,0,0" Click="Recalibrate_Click"/>
+            <Separator/>
+            <Button Content="Mode Calibration" Margin="6,0,0,0" Click="ToggleCalibrationMode_Click" x:Name="CalibrationModeButton"/>
+            <Button Content="+ Ligne horizontale" Margin="6,0,0,0" Click="AddHorizontalLine_Click" x:Name="AddHorizontalButton" IsEnabled="False"/>
+            <Button Content="+ Ligne verticale" Margin="6,0,0,0" Click="AddVerticalLine_Click" x:Name="AddVerticalButton" IsEnabled="False"/>
+            <Button Content="Sauvegarder calibration" Margin="6,0,0,0" Click="SaveCalibration_Click" x:Name="SaveCalibrationButton" IsEnabled="False"/>
+            <Button Content="Charger calibration" Margin="6,0,0,0" Click="LoadCalibration_Click" x:Name="LoadCalibrationButton"/>
             <Separator/>
             <TextBlock Text="Date :" VerticalAlignment="Center"/>
             <DatePicker x:Name="DocumentDatePicker" Width="140" Margin="6,0"/>
@@ -45,6 +50,35 @@
                                             MouseLeftButtonDown="Overlay_MouseLeftButtonDown"
                                             MouseMove="Overlay_MouseMove"
                                             MouseLeftButtonUp="Overlay_MouseLeftButtonUp">
+                                        <!-- Calibration lines -->
+                                        <ItemsControl ItemsSource="{Binding CalibrationLines}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <Canvas />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Canvas>
+                                                        <Line X1="{Binding X1}" Y1="{Binding Y1}" 
+                                                              X2="{Binding X2}" Y2="{Binding Y2}" 
+                                                              Stroke="{Binding LineBrush}" 
+                                                              StrokeThickness="2" 
+                                                              StrokeDashArray="4 2"
+                                                              MouseLeftButtonDown="CalibrationLine_MouseLeftButtonDown"/>
+                                                        <TextBlock Text="{Binding Label}" 
+                                                                   Canvas.Left="{Binding LabelX}" 
+                                                                   Canvas.Top="{Binding LabelY}" 
+                                                                   Background="White" 
+                                                                   Padding="2" 
+                                                                   FontSize="10" 
+                                                                   FontWeight="Bold"
+                                                                   Foreground="{Binding LineBrush}"/>
+                                                    </Canvas>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                        <!-- Placements -->
                                         <ItemsControl ItemsSource="{Binding Placements}">
                                             <ItemsControl.ItemsPanel>
                                                 <ItemsPanelTemplate>

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml
@@ -12,6 +12,7 @@
             <Button Content="Mode Calibration" Margin="6,0,0,0" Click="ToggleCalibrationMode_Click" x:Name="CalibrationModeButton"/>
             <Button Content="+ Ligne horizontale" Margin="6,0,0,0" Click="AddHorizontalLine_Click" x:Name="AddHorizontalButton" IsEnabled="False"/>
             <Button Content="+ Ligne verticale" Margin="6,0,0,0" Click="AddVerticalLine_Click" x:Name="AddVerticalButton" IsEnabled="False"/>
+            <Button Content="👁️ Lignes" Margin="6,0,0,0" Click="ToggleCalibrationLinesVisibility_Click" x:Name="ToggleLinesButton" ToolTip="Afficher/Masquer les lignes de calibration"/>
             <Button Content="Réinitialiser calibration" Margin="6,0,0,0" Click="ResetCalibration_Click" x:Name="ResetCalibrationButton" IsEnabled="False" Foreground="Red"/>
             <Separator/>
             <Button Content="Sauvegarder calibration" Margin="6,0,0,0" Click="SaveCalibration_Click" x:Name="SaveCalibrationButton" IsEnabled="False"/>
@@ -61,7 +62,7 @@
                                             </ItemsControl.ItemsPanel>
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <Canvas>
+                                                    <Canvas Visibility="{Binding LineVisibility}">
                                                         <Line X1="{Binding X1}" Y1="{Binding Y1}" 
                                                               X2="{Binding X2}" Y2="{Binding Y2}" 
                                                               Stroke="{Binding LineBrush}" 

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml
@@ -1,0 +1,82 @@
+<Window x:Class="Ploco.Dialogs.PlanningPdfWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Planning PDF" Height="720" Width="1100"
+        WindowStartupLocation="CenterOwner">
+    <DockPanel>
+        <ToolBar DockPanel.Dock="Top">
+            <Button Content="Charger PDF" Click="LoadPdf_Click"/>
+            <Button Content="Exporter PDF annoté" Margin="6,0,0,0" Click="ExportPdf_Click"/>
+            <Button Content="Exporter CSV" Margin="6,0,0,0" Click="ExportCsv_Click"/>
+            <Button Content="Recalibrer" Margin="6,0,0,0" Click="Recalibrate_Click"/>
+            <Separator/>
+            <TextBlock Text="Date :" VerticalAlignment="Center"/>
+            <DatePicker x:Name="DocumentDatePicker" Width="140" Margin="6,0"/>
+            <Separator/>
+            <TextBlock Text="Zoom" VerticalAlignment="Center"/>
+            <Slider x:Name="ZoomSlider" Width="140" Minimum="0.5" Maximum="2.5" Value="1.0" ValueChanged="ZoomSlider_ValueChanged"/>
+            <TextBlock x:Name="ZoomLabel" Text="100%" Width="60" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+        </ToolBar>
+
+        <ScrollViewer x:Name="PdfScrollViewer" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+            <ItemsControl x:Name="PdfPages">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border BorderBrush="#FFDDDDDD" BorderThickness="1" Margin="8" Padding="8">
+                            <Grid>
+                                <Image Source="{Binding PageImage}" Stretch="Fill"
+                                       Width="{Binding PageWidth}" Height="{Binding PageHeight}"/>
+                                <Canvas Width="{Binding PageWidth}" Height="{Binding PageHeight}"
+                                        Background="Transparent"
+                                        AllowDrop="True"
+                                        Drop="Overlay_Drop"
+                                        DragOver="Overlay_DragOver"
+                                        MouseLeftButtonDown="Overlay_MouseLeftButtonDown"
+                                        MouseMove="Overlay_MouseMove"
+                                        MouseLeftButtonUp="Overlay_MouseLeftButtonUp">
+                                    <ItemsControl ItemsSource="{Binding Placements}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <Canvas />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemContainerStyle>
+                                            <Style TargetType="ContentPresenter">
+                                                <Setter Property="Canvas.Left" Value="{Binding X}" />
+                                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                                            </Style>
+                                        </ItemsControl.ItemContainerStyle>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Padding="4" CornerRadius="4" Background="{Binding StatusBrush}"
+                                                        BorderBrush="#FF333333" BorderThickness="1"
+                                                        PreviewMouseLeftButtonDown="Token_MouseLeftButtonDown"
+                                                        PreviewMouseMove="Token_MouseMove">
+                                                    <Border.ContextMenu>
+                                                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                                            <MenuItem Header="Modifier" Click="EditPlacement_Click"/>
+                                                            <MenuItem Header="Supprimer" Click="DeletePlacement_Click"/>
+                                                        </ContextMenu>
+                                                    </Border.ContextMenu>
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding LocNumber}" FontWeight="Bold" Foreground="White"/>
+                                                        <TextBlock Text="{Binding BadgeText}" FontSize="10" Foreground="White"/>
+                                                    </StackPanel>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </Canvas>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml.cs
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml.cs
@@ -568,7 +568,7 @@ namespace Ploco.Dialogs
                     .Select(w => new
                     {
                         Id = w.Text.StartsWith("@") ? w.Text : $"@{w.Text}",
-                        Y = w.BoundingBox.Center.Y
+                        Y = (w.BoundingBox.Bottom + w.BoundingBox.Top) / 2
                     })
                     .GroupBy(item => item.Id)
                     .Select(group => new PdfTemplateRowMapping
@@ -580,7 +580,7 @@ namespace Ploco.Dialogs
 
                 var timeCandidates = words
                     .Where(w => timeRegex.IsMatch(w.Text))
-                    .Select(w => new { Hour = int.Parse(w.Text, CultureInfo.InvariantCulture), X = w.BoundingBox.Center.X })
+                    .Select(w => new { Hour = int.Parse(w.Text, CultureInfo.InvariantCulture), X = (w.BoundingBox.Left + w.BoundingBox.Right) / 2 })
                     .GroupBy(item => item.Hour)
                     .Select(group => new { Hour = group.Key, X = group.Average(item => item.X) })
                     .ToList();

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml.cs
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml.cs
@@ -1,0 +1,786 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Docnet.Core;
+using Docnet.Core.Models;
+using Microsoft.Win32;
+using PdfSharpCore.Drawing;
+using PdfSharpCore.Pdf.IO;
+using Ploco.Data;
+using Ploco.Models;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
+
+namespace Ploco.Dialogs
+{
+    public partial class PlanningPdfWindow : Window
+    {
+        private readonly PlocoRepository _repository;
+        private readonly ObservableCollection<PdfPageViewModel> _pages = new();
+        private PdfDocumentModel? _document;
+        private readonly Dictionary<int, PdfTemplateCalibrationModel> _calibrations = new();
+        private readonly Dictionary<int, (double Width, double Height)> _pdfPageSizes = new();
+        private double _zoom = 1.0;
+        private bool _isDraggingToken;
+        private PdfPlacementViewModel? _draggedPlacement;
+        private Point _dragStart;
+        private bool _isCalibrationMode;
+        private CalibrationStep _calibrationStep = CalibrationStep.None;
+
+        public PlanningPdfWindow(PlocoRepository repository)
+        {
+            InitializeComponent();
+            _repository = repository;
+            PdfPages.ItemsSource = _pages;
+            DocumentDatePicker.SelectedDate = DateTime.Today;
+            UpdateZoomLabel();
+        }
+
+        private void LoadPdf_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new OpenFileDialog
+            {
+                Filter = "PDF (*.pdf)|*.pdf",
+                Title = "Choisir un PDF"
+            };
+
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            LoadPdf(dialog.FileName);
+        }
+
+        private void LoadPdf(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                MessageBox.Show("Fichier introuvable.", "Planning PDF", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            _pages.Clear();
+            _calibrations.Clear();
+            _pdfPageSizes.Clear();
+
+            var date = DocumentDatePicker.SelectedDate ?? DateTime.Today;
+            var templateHash = ComputeFileHash(filePath);
+            var pageCount = GetPdfPageCount(filePath);
+            _document = _repository.GetPdfDocument(filePath, date) ?? new PdfDocumentModel
+            {
+                FilePath = filePath,
+                DocumentDate = date,
+                TemplateHash = templateHash,
+                PageCount = pageCount
+            };
+
+            _document.TemplateHash = templateHash;
+            _document.PageCount = pageCount;
+            _document = _repository.SavePdfDocument(_document);
+
+            var calibrations = _repository.LoadTemplateCalibrations(templateHash);
+            foreach (var calibration in calibrations)
+            {
+                _calibrations[calibration.PageIndex] = calibration;
+            }
+
+            var extracted = ExtractCalibration(filePath);
+            foreach (var calibration in extracted)
+            {
+                if (!_calibrations.ContainsKey(calibration.PageIndex))
+                {
+                    _calibrations[calibration.PageIndex] = calibration;
+                    _repository.SaveTemplateCalibration(calibration);
+                }
+            }
+
+            RenderPages(filePath);
+            LoadPlacements();
+        }
+
+        private void RenderPages(string filePath)
+        {
+            var renderer = DocLib.Instance.GetDocReader(filePath, new PageDimensions(1440, 2030));
+            for (var pageIndex = 0; pageIndex < renderer.GetPageCount(); pageIndex++)
+            {
+                using var pageReader = renderer.GetPageReader(pageIndex);
+                var rawBytes = pageReader.GetImage();
+                var (pdfWidth, pdfHeight) = _pdfPageSizes.TryGetValue(pageIndex, out var size) ? size : (pageReader.GetPageWidth(), pageReader.GetPageHeight());
+                var page = new PdfPageViewModel(pageIndex, rawBytes, pageReader.GetPageWidth(), pageReader.GetPageHeight(), pdfWidth, pdfHeight);
+                page.ApplyZoom(_zoom);
+                _pages.Add(page);
+            }
+        }
+
+        private void LoadPlacements()
+        {
+            if (_document == null)
+            {
+                return;
+            }
+
+            var placements = _repository.LoadPlacements(_document.Id);
+            foreach (var page in _pages)
+            {
+                page.Placements.Clear();
+            }
+
+            foreach (var placement in placements)
+            {
+                var page = _pages.FirstOrDefault(p => p.PageIndex == placement.PageIndex);
+                if (page == null)
+                {
+                    continue;
+                }
+
+                var vm = PdfPlacementViewModel.FromModel(placement);
+                ApplyPlacementPosition(page, vm);
+                page.Placements.Add(vm);
+            }
+        }
+
+        private void ApplyPlacementPosition(PdfPageViewModel page, PdfPlacementViewModel placement)
+        {
+            if (!_calibrations.TryGetValue(page.PageIndex, out var calibration))
+            {
+                placement.X = 10;
+                placement.Y = 10;
+                return;
+            }
+
+            var x = MapMinuteToX(calibration, page, placement.MinuteOfDay);
+            var row = calibration.Rows.FirstOrDefault(r => string.Equals(r.RoulementId, placement.RoulementId, StringComparison.OrdinalIgnoreCase));
+            var y = row != null ? MapPdfYToImage(page, row.YCenter) : 10;
+            placement.X = x - placement.Width / 2;
+            placement.Y = y - placement.Height / 2;
+        }
+
+        private void Overlay_DragOver(object sender, DragEventArgs e)
+        {
+            if (!e.Data.GetDataPresent(typeof(LocomotiveModel)) && !_isDraggingToken)
+            {
+                e.Effects = DragDropEffects.None;
+                return;
+            }
+
+            e.Effects = DragDropEffects.Move;
+            e.Handled = true;
+        }
+
+        private void Overlay_Drop(object sender, DragEventArgs e)
+        {
+            if (sender is not Canvas canvas || canvas.DataContext is not PdfPageViewModel page)
+            {
+                return;
+            }
+
+            if (_document == null)
+            {
+                MessageBox.Show("Chargez un PDF avant d'ajouter des placements.", "Planning PDF", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (!_calibrations.TryGetValue(page.PageIndex, out var calibration))
+            {
+                MessageBox.Show("Calibration manquante pour cette page. Lancez un recalibrage.", "Planning PDF",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var dropPoint = GetCanvasPoint(e.GetPosition(canvas));
+            if (_isDraggingToken && _draggedPlacement != null)
+            {
+                UpdatePlacementFromDrop(page, calibration, _draggedPlacement, dropPoint);
+                _isDraggingToken = false;
+                _draggedPlacement = null;
+                return;
+            }
+
+            if (!e.Data.GetDataPresent(typeof(LocomotiveModel)))
+            {
+                return;
+            }
+
+            var loco = (LocomotiveModel)e.Data.GetData(typeof(LocomotiveModel))!;
+            var placement = BuildPlacementFromLocomotive(loco, _document.Id, page.PageIndex);
+            UpdatePlacementFromDrop(page, calibration, placement, dropPoint);
+            SavePlacement(page, placement);
+        }
+
+        private void UpdatePlacementFromDrop(PdfPageViewModel page, PdfTemplateCalibrationModel calibration, PdfPlacementViewModel placement, Point dropPoint)
+        {
+            var minute = MapXToMinute(calibration, page, dropPoint.X);
+            var row = FindNearestRow(calibration, page, dropPoint.Y);
+            if (row == null)
+            {
+                MessageBox.Show("Aucun roulement détecté pour ce drop.", "Planning PDF", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            placement.MinuteOfDay = minute;
+            placement.RoulementId = row.RoulementId;
+            placement.X = dropPoint.X - placement.Width / 2;
+            placement.Y = dropPoint.Y - placement.Height / 2;
+
+            if (placement.Id == 0)
+            {
+                page.Placements.Add(placement);
+            }
+            else
+            {
+                SavePlacement(page, placement);
+            }
+        }
+
+        private void SavePlacement(PdfPageViewModel page, PdfPlacementViewModel placement)
+        {
+            if (_document == null)
+            {
+                return;
+            }
+
+            var existing = _pages.SelectMany(p => p.Placements)
+                .FirstOrDefault(p => p.LocNumber == placement.LocNumber && p.Id != placement.Id);
+            if (existing != null)
+            {
+                var existingPage = _pages.FirstOrDefault(p => p.Placements.Contains(existing));
+                existingPage?.Placements.Remove(existing);
+                if (existing.Id > 0)
+                {
+                    _repository.DeletePlacement(existing.Id);
+                }
+            }
+
+            placement.PdfDocumentId = _document.Id;
+            var model = placement.ToModel();
+            _repository.SavePlacement(model);
+            placement.Id = model.Id;
+            placement.UpdatedAt = model.UpdatedAt;
+            placement.CreatedAt = model.CreatedAt;
+        }
+
+        private PdfPlacementViewModel BuildPlacementFromLocomotive(LocomotiveModel loco, int documentId, int pageIndex)
+        {
+            return new PdfPlacementViewModel
+            {
+                PdfDocumentId = documentId,
+                PageIndex = pageIndex,
+                LocNumber = loco.Number,
+                Status = loco.Status,
+                TractionPercent = loco.TractionPercent,
+                HsReason = loco.HsReason
+            };
+        }
+
+        private void Token_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is Border border && border.DataContext is PdfPlacementViewModel placement)
+            {
+                _draggedPlacement = placement;
+                _dragStart = e.GetPosition(PdfPages);
+                _isDraggingToken = true;
+                border.CaptureMouse();
+            }
+        }
+
+        private void Token_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (!_isDraggingToken || _draggedPlacement == null || e.LeftButton != MouseButtonState.Pressed)
+            {
+                return;
+            }
+
+            if (sender is Border border)
+            {
+                DragDrop.DoDragDrop(border, _draggedPlacement, DragDropEffects.Move);
+            }
+        }
+
+        private void Overlay_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (!_isCalibrationMode || sender is not Canvas canvas || canvas.DataContext is not PdfPageViewModel page)
+            {
+                return;
+            }
+
+            if (!_calibrations.TryGetValue(page.PageIndex, out var calibration))
+            {
+                calibration = new PdfTemplateCalibrationModel
+                {
+                    TemplateHash = _document?.TemplateHash ?? string.Empty,
+                    PageIndex = page.PageIndex,
+                    XStart = 0,
+                    XEnd = page.PageWidth
+                };
+                _calibrations[page.PageIndex] = calibration;
+            }
+
+            var point = GetCanvasPoint(e.GetPosition(canvas));
+            var pdfX = MapImageXToPdf(page, point.X);
+            var pdfY = MapImageYToPdf(page, point.Y);
+
+            if (_calibrationStep == CalibrationStep.SelectStart)
+            {
+                calibration.XStart = pdfX;
+                _calibrationStep = CalibrationStep.SelectEnd;
+                MessageBox.Show("Cliquez sur la position 24:00.", "Calibrage", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else if (_calibrationStep == CalibrationStep.SelectEnd)
+            {
+                calibration.XEnd = pdfX;
+                _calibrationStep = CalibrationStep.SelectRows;
+                MessageBox.Show("Cliquez sur une ligne et saisissez son identifiant.", "Calibrage", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else if (_calibrationStep == CalibrationStep.SelectRows)
+            {
+                var input = new SimpleTextDialog("Roulement", "Identifiant (ex: @1101) :", string.Empty)
+                {
+                    Owner = this
+                };
+                if (input.ShowDialog() == true && !string.IsNullOrWhiteSpace(input.ResponseText))
+                {
+                    calibration.Rows.Add(new PdfTemplateRowMapping
+                    {
+                        RoulementId = input.ResponseText.Trim(),
+                        YCenter = pdfY
+                    });
+                }
+            }
+
+            _repository.SaveTemplateCalibration(calibration);
+        }
+
+        private void Overlay_MouseMove(object sender, MouseEventArgs e)
+        {
+        }
+
+        private void Overlay_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            _isDraggingToken = false;
+            _draggedPlacement = null;
+        }
+
+        private void EditPlacement_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.DataContext is PdfPlacementViewModel placement)
+            {
+                var dialog = new PdfPlacementDialog(placement) { Owner = this };
+                if (dialog.ShowDialog() == true)
+                {
+                    SavePlacement(_pages.First(p => p.PageIndex == placement.PageIndex), placement);
+                }
+            }
+        }
+
+        private void DeletePlacement_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.DataContext is PdfPlacementViewModel placement)
+            {
+                var page = _pages.First(p => p.PageIndex == placement.PageIndex);
+                page.Placements.Remove(placement);
+                if (placement.Id > 0)
+                {
+                    _repository.DeletePlacement(placement.Id);
+                }
+            }
+        }
+
+        private void ExportPdf_Click(object sender, RoutedEventArgs e)
+        {
+            if (_document == null)
+            {
+                MessageBox.Show("Aucun PDF chargé.", "Planning PDF", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var dialog = new SaveFileDialog
+            {
+                Filter = "PDF (*.pdf)|*.pdf",
+                FileName = $"planning_{_document.DocumentDate:yyyyMMdd}.pdf"
+            };
+
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            ExportPdf(dialog.FileName);
+        }
+
+        private void ExportPdf(string outputPath)
+        {
+            if (_document == null)
+            {
+                return;
+            }
+
+            using var input = PdfReader.Open(_document.FilePath, PdfDocumentOpenMode.Modify);
+            foreach (var page in _pages)
+            {
+                if (!_calibrations.TryGetValue(page.PageIndex, out var calibration))
+                {
+                    continue;
+                }
+
+                var pdfPage = input.Pages[page.PageIndex];
+                using var gfx = XGraphics.FromPdfPage(pdfPage);
+                foreach (var placement in page.Placements)
+                {
+                    var xPdf = MapMinuteToPdfX(calibration, placement.MinuteOfDay);
+                    var row = calibration.Rows.FirstOrDefault(r => string.Equals(r.RoulementId, placement.RoulementId, StringComparison.OrdinalIgnoreCase));
+                    if (row == null)
+                    {
+                        continue;
+                    }
+
+                    var yPdf = row.YCenter;
+                    var rectWidth = 46;
+                    var rectHeight = 18;
+                    var x = xPdf - rectWidth / 2;
+                    var y = pdfPage.Height - yPdf - rectHeight / 2;
+
+                    var brush = placement.Status switch
+                    {
+                        LocomotiveStatus.HS => XBrushes.IndianRed,
+                        LocomotiveStatus.ManqueTraction => XBrushes.Orange,
+                        _ => XBrushes.SeaGreen
+                    };
+                    gfx.DrawRectangle(brush, x, y, rectWidth, rectHeight);
+                    var font = new XFont("Arial", 8, XFontStyle.Bold);
+                    gfx.DrawString(placement.LocNumber.ToString(), font, XBrushes.White,
+                        new XRect(x, y, rectWidth, rectHeight), XStringFormats.CenterLeft);
+
+                    var badge = placement.Status == LocomotiveStatus.ManqueTraction && placement.TractionPercent.HasValue
+                        ? $"{placement.TractionPercent}%"
+                        : placement.Status == LocomotiveStatus.HS ? "HS" : string.Empty;
+                    if (!string.IsNullOrWhiteSpace(badge))
+                    {
+                        gfx.DrawString(badge, new XFont("Arial", 7, XFontStyle.Regular), XBrushes.White,
+                            new XRect(x, y, rectWidth, rectHeight), XStringFormats.CenterRight);
+                    }
+                }
+            }
+
+            input.Save(outputPath);
+            MessageBox.Show("Export terminé.", "Planning PDF", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void ExportCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (_document == null)
+            {
+                return;
+            }
+
+            var dialog = new SaveFileDialog
+            {
+                Filter = "CSV (*.csv)|*.csv",
+                FileName = $"planning_{_document.DocumentDate:yyyyMMdd}.csv"
+            };
+
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            var builder = new StringBuilder();
+            builder.AppendLine("pageIndex,roulementId,minuteOfDay,heure,locNumber,status,tractionPercent,onTrain,trainNumber,hsReason,comment");
+            foreach (var placement in _pages.SelectMany(p => p.Placements))
+            {
+                var time = TimeSpan.FromMinutes(placement.MinuteOfDay);
+                builder.AppendLine($"{placement.PageIndex},{placement.RoulementId},{placement.MinuteOfDay},{time:hh\\:mm},{placement.LocNumber},{placement.Status},{placement.TractionPercent},{placement.OnTrain},{placement.TrainNumber},{placement.HsReason},{placement.Comment}");
+            }
+
+            File.WriteAllText(dialog.FileName, builder.ToString(), Encoding.UTF8);
+            MessageBox.Show("Export CSV terminé.", "Planning PDF", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void Recalibrate_Click(object sender, RoutedEventArgs e)
+        {
+            if (_document == null)
+            {
+                MessageBox.Show("Chargez un PDF avant de calibrer.", "Planning PDF", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            _isCalibrationMode = !_isCalibrationMode;
+            _calibrationStep = _isCalibrationMode ? CalibrationStep.SelectStart : CalibrationStep.None;
+            MessageBox.Show(_isCalibrationMode
+                    ? "Mode calibrage activé. Cliquez sur la position 00:00."
+                    : "Mode calibrage désactivé.",
+                "Calibrage", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void ZoomSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            _zoom = e.NewValue;
+            UpdateZoomLabel();
+            foreach (var page in _pages)
+            {
+                page.ApplyZoom(_zoom);
+            }
+        }
+
+        private void UpdateZoomLabel()
+        {
+            ZoomLabel.Text = $"{_zoom:P0}";
+        }
+
+        private static int GetPdfPageCount(string filePath)
+        {
+            using var pdf = PdfDocument.Open(filePath);
+            return pdf.NumberOfPages;
+        }
+
+        private static string ComputeFileHash(string filePath)
+        {
+            using var stream = File.OpenRead(filePath);
+            using var sha = SHA256.Create();
+            return Convert.ToHexString(sha.ComputeHash(stream));
+        }
+
+        private List<PdfTemplateCalibrationModel> ExtractCalibration(string filePath)
+        {
+            var results = new List<PdfTemplateCalibrationModel>();
+            using var pdf = PdfDocument.Open(filePath);
+            var rowRegex = new Regex(@"@?\d{4}", RegexOptions.Compiled);
+            var timeRegex = new Regex(@"^(?:[01]?\d|2[0-3])$", RegexOptions.Compiled);
+
+            for (var pageIndex = 0; pageIndex < pdf.NumberOfPages; pageIndex++)
+            {
+                var page = pdf.GetPage(pageIndex);
+                _pdfPageSizes[pageIndex] = (page.Width, page.Height);
+                var words = page.GetWords().ToList();
+                var rowCandidates = words
+                    .Where(w => rowRegex.IsMatch(w.Text))
+                    .Select(w => new
+                    {
+                        Id = w.Text.StartsWith("@") ? w.Text : $"@{w.Text}",
+                        Y = w.BoundingBox.Center.Y
+                    })
+                    .GroupBy(item => item.Id)
+                    .Select(group => new PdfTemplateRowMapping
+                    {
+                        RoulementId = group.Key,
+                        YCenter = group.Average(item => item.Y)
+                    })
+                    .ToList();
+
+                var timeCandidates = words
+                    .Where(w => timeRegex.IsMatch(w.Text))
+                    .Select(w => new { Hour = int.Parse(w.Text, CultureInfo.InvariantCulture), X = w.BoundingBox.Center.X })
+                    .GroupBy(item => item.Hour)
+                    .Select(group => new { Hour = group.Key, X = group.Average(item => item.X) })
+                    .ToList();
+
+                if (!rowCandidates.Any() || timeCandidates.Count < 2)
+                {
+                    continue;
+                }
+
+                var xStart = timeCandidates.OrderBy(t => t.Hour).First().X;
+                var xEnd = timeCandidates.OrderBy(t => t.Hour).Last().X;
+                results.Add(new PdfTemplateCalibrationModel
+                {
+                    TemplateHash = _document?.TemplateHash ?? string.Empty,
+                    PageIndex = pageIndex,
+                    XStart = xStart,
+                    XEnd = xEnd,
+                    Rows = rowCandidates
+                });
+            }
+
+            return results;
+        }
+
+        private static int MapXToMinute(PdfTemplateCalibrationModel calibration, PdfPageViewModel page, double xImage)
+        {
+            var pdfX = MapImageXToPdf(page, xImage);
+            var ratio = (pdfX - calibration.XStart) / (calibration.XEnd - calibration.XStart);
+            ratio = Math.Max(0, Math.Min(1, ratio));
+            return (int)Math.Round(ratio * 1440);
+        }
+
+        private static double MapMinuteToX(PdfTemplateCalibrationModel calibration, PdfPageViewModel page, int minute)
+        {
+            var pdfX = MapMinuteToPdfX(calibration, minute);
+            return MapPdfXToImage(page, pdfX);
+        }
+
+        private static double MapMinuteToPdfX(PdfTemplateCalibrationModel calibration, int minute)
+        {
+            var ratio = minute / 1440.0;
+            return calibration.XStart + ratio * (calibration.XEnd - calibration.XStart);
+        }
+
+        private static PdfTemplateRowMapping? FindNearestRow(PdfTemplateCalibrationModel calibration, PdfPageViewModel page, double yImage)
+        {
+            var pdfY = MapImageYToPdf(page, yImage);
+            return calibration.Rows.OrderBy(r => Math.Abs(r.YCenter - pdfY)).FirstOrDefault();
+        }
+
+        private static double MapPdfXToImage(PdfPageViewModel page, double pdfX)
+        {
+            return pdfX * page.ScaleX;
+        }
+
+        private static double MapPdfYToImage(PdfPageViewModel page, double pdfY)
+        {
+            return (page.PdfHeight - pdfY) * page.ScaleY;
+        }
+
+        private static double MapImageXToPdf(PdfPageViewModel page, double imageX)
+        {
+            return imageX / page.ScaleX;
+        }
+
+        private static double MapImageYToPdf(PdfPageViewModel page, double imageY)
+        {
+            return page.PdfHeight - (imageY / page.ScaleY);
+        }
+
+        private Point GetCanvasPoint(Point position)
+        {
+            return new Point(position.X / _zoom, position.Y / _zoom);
+        }
+
+        private sealed class PdfPageViewModel
+        {
+            public int PageIndex { get; }
+            public BitmapSource PageImage { get; }
+            public double PdfWidth { get; }
+            public double PdfHeight { get; }
+            public double ScaleX { get; private set; }
+            public double ScaleY { get; private set; }
+            public double PageWidth { get; private set; }
+            public double PageHeight { get; private set; }
+            public ObservableCollection<PdfPlacementViewModel> Placements { get; } = new();
+
+            public PdfPageViewModel(int pageIndex, byte[] imageBytes, int width, int height, double pdfWidth, double pdfHeight)
+            {
+                PageIndex = pageIndex;
+                PdfWidth = pdfWidth;
+                PdfHeight = pdfHeight;
+                PageImage = BitmapSource.Create(width, height, 96, 96, PixelFormats.Bgra32, null, imageBytes, width * 4);
+                ApplyZoom(1.0);
+            }
+
+            public void ApplyZoom(double zoom)
+            {
+                PageWidth = PageImage.PixelWidth * zoom;
+                PageHeight = PageImage.PixelHeight * zoom;
+                ScaleX = PageWidth / PdfWidth;
+                ScaleY = PageHeight / PdfHeight;
+            }
+        }
+
+        public class PdfPlacementViewModel
+        {
+            public int Id { get; set; }
+            public int PdfDocumentId { get; set; }
+            public int PageIndex { get; set; }
+            public string RoulementId { get; set; } = string.Empty;
+            public int MinuteOfDay { get; set; }
+            public int LocNumber { get; set; }
+            public LocomotiveStatus Status { get; set; }
+            public int? TractionPercent { get; set; }
+            public int? MotorsHsCount { get; set; }
+            public string? HsReason { get; set; }
+            public bool OnTrain { get; set; }
+            public string? TrainNumber { get; set; }
+            public string? TrainStopTime { get; set; }
+            public string? Comment { get; set; }
+            public DateTime CreatedAt { get; set; }
+            public DateTime UpdatedAt { get; set; }
+            public double X { get; set; }
+            public double Y { get; set; }
+            public double Width => 48;
+            public double Height => 24;
+            public Brush StatusBrush => Status switch
+            {
+                LocomotiveStatus.HS => Brushes.IndianRed,
+                LocomotiveStatus.ManqueTraction => Brushes.Orange,
+                _ => Brushes.SeaGreen
+            };
+
+            public string BadgeText
+            {
+                get
+                {
+                    if (Status == LocomotiveStatus.ManqueTraction && TractionPercent.HasValue)
+                    {
+                        return $"{TractionPercent}%";
+                    }
+
+                    return Status == LocomotiveStatus.HS ? "HS" : string.Empty;
+                }
+            }
+
+            public PdfPlacementModel ToModel()
+            {
+                return new PdfPlacementModel
+                {
+                    Id = Id,
+                    PdfDocumentId = PdfDocumentId,
+                    PageIndex = PageIndex,
+                    RoulementId = RoulementId,
+                    MinuteOfDay = MinuteOfDay,
+                    LocNumber = LocNumber,
+                    Status = Status,
+                    TractionPercent = TractionPercent,
+                    MotorsHsCount = MotorsHsCount,
+                    HsReason = HsReason,
+                    OnTrain = OnTrain,
+                    TrainNumber = TrainNumber,
+                    TrainStopTime = TrainStopTime,
+                    Comment = Comment,
+                    CreatedAt = CreatedAt,
+                    UpdatedAt = UpdatedAt
+                };
+            }
+
+            public static PdfPlacementViewModel FromModel(PdfPlacementModel model)
+            {
+                return new PdfPlacementViewModel
+                {
+                    Id = model.Id,
+                    PdfDocumentId = model.PdfDocumentId,
+                    PageIndex = model.PageIndex,
+                    RoulementId = model.RoulementId,
+                    MinuteOfDay = model.MinuteOfDay,
+                    LocNumber = model.LocNumber,
+                    Status = model.Status,
+                    TractionPercent = model.TractionPercent,
+                    MotorsHsCount = model.MotorsHsCount,
+                    HsReason = model.HsReason,
+                    OnTrain = model.OnTrain,
+                    TrainNumber = model.TrainNumber,
+                    TrainStopTime = model.TrainStopTime,
+                    Comment = model.Comment,
+                    CreatedAt = model.CreatedAt,
+                    UpdatedAt = model.UpdatedAt
+                };
+            }
+        }
+
+        private enum CalibrationStep
+        {
+            None,
+            SelectStart,
+            SelectEnd,
+            SelectRows
+        }
+    }
+}

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml.cs
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml.cs
@@ -535,7 +535,10 @@ namespace Ploco.Dialogs
 
         private void UpdateZoomLabel()
         {
-            ZoomLabel.Text = $"{_zoom:P0}";
+            if (ZoomLabel != null)
+            {
+                ZoomLabel.Text = $"{_zoom:P0}";
+            }
         }
 
         private static int GetPdfPageCount(string filePath)

--- a/Ploco/Dialogs/PlanningPdfWindow.xaml.cs
+++ b/Ploco/Dialogs/PlanningPdfWindow.xaml.cs
@@ -563,7 +563,7 @@ namespace Ploco.Dialogs
 
             for (var pageIndex = 0; pageIndex < pdf.NumberOfPages; pageIndex++)
             {
-                var page = pdf.GetPage(pageIndex);
+                var page = pdf.GetPage(pageIndex + 1);
                 _pdfPageSizes[pageIndex] = (page.Width, page.Height);
                 var words = page.GetWords().ToList();
                 var rowCandidates = words

--- a/Ploco/Dialogs/RollingLineRangeDialog.xaml
+++ b/Ploco/Dialogs/RollingLineRangeDialog.xaml
@@ -1,0 +1,46 @@
+<Window x:Class="Ploco.Dialogs.RollingLineRangeDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configurer lignes de roulement" Height="300" Width="500"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Spécifiez les plages de numéros de lignes" FontWeight="SemiBold" Margin="0,0,0,8"/>
+        
+        <TextBlock Grid.Row="1" TextWrapping="Wrap" Margin="0,0,0,12">
+            <Run Text="Exemples : "/>
+            <Run Text="1101-1112" FontWeight="Bold"/>
+            <Run Text=" ou "/>
+            <Run Text="1101-1112, 1113-1125" FontWeight="Bold"/>
+            <LineBreak/>
+            <Run Text="Vous pouvez également saisir un nombre unique comme "/>
+            <Run Text="23" FontWeight="Bold"/>
+            <Run Text=" pour créer les lignes 1101 à 1123"/>
+        </TextBlock>
+
+        <TextBlock Grid.Row="2" Text="Plages de lignes :" FontWeight="SemiBold" Margin="0,0,0,4"/>
+        <TextBox Grid.Row="3" x:Name="RangesText" Margin="0,0,0,12" 
+                 VerticalAlignment="Top" Height="60" 
+                 TextWrapping="Wrap" AcceptsReturn="True"
+                 ToolTip="Entrez les plages (ex: 1101-1112, 1113-1125) ou un nombre simple (ex: 23)"/>
+
+        <TextBlock Grid.Row="4" x:Name="PreviewText" 
+                   TextWrapping="Wrap" 
+                   Foreground="Gray" 
+                   FontStyle="Italic"
+                   VerticalAlignment="Top"/>
+
+        <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/RollingLineRangeDialog.xaml.cs
+++ b/Ploco/Dialogs/RollingLineRangeDialog.xaml.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Ploco.Dialogs
+{
+    public partial class RollingLineRangeDialog : Window
+    {
+        private const int RollingLineStartNumber = 1101;
+        public List<int> SelectedNumbers { get; private set; } = new List<int>();
+
+        public RollingLineRangeDialog(string initialValue)
+        {
+            InitializeComponent();
+            RangesText.Text = initialValue;
+            RangesText.TextChanged += RangesText_TextChanged;
+            RangesText.Focus();
+            RangesText.SelectAll();
+            UpdatePreview();
+        }
+
+        private void RangesText_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            UpdatePreview();
+        }
+
+        private void UpdatePreview()
+        {
+            var input = RangesText.Text.Trim();
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                PreviewText.Text = "";
+                return;
+            }
+
+            var (success, numbers, error) = ParseInput(input);
+            if (success)
+            {
+                var count = numbers.Count;
+                var min = numbers.Min();
+                var max = numbers.Max();
+                PreviewText.Text = $"✓ {count} ligne{(count > 1 ? "s" : "")} : {min} à {max}";
+                PreviewText.Foreground = System.Windows.Media.Brushes.Green;
+            }
+            else
+            {
+                PreviewText.Text = $"✗ {error}";
+                PreviewText.Foreground = System.Windows.Media.Brushes.Red;
+            }
+        }
+
+        private (bool success, List<int> numbers, string error) ParseInput(string input)
+        {
+            input = input.Trim();
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return (false, new List<int>(), "Veuillez saisir une valeur");
+            }
+
+            // Check if it's a simple number (backward compatibility)
+            if (int.TryParse(input, out var simpleCount))
+            {
+                if (simpleCount <= 0)
+                {
+                    return (false, new List<int>(), "Le nombre doit être supérieur à 0");
+                }
+                var numbers = Enumerable.Range(RollingLineStartNumber, simpleCount).ToList();
+                return (true, numbers, string.Empty);
+            }
+
+            // Parse ranges like "1101-1112, 1113-1125"
+            var result = new HashSet<int>();
+            var parts = input.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var part in parts)
+            {
+                var trimmed = part.Trim();
+                if (trimmed.Contains('-'))
+                {
+                    // Range format
+                    var rangeParts = trimmed.Split('-');
+                    if (rangeParts.Length != 2)
+                    {
+                        return (false, new List<int>(), $"Format invalide : '{trimmed}' (utilisez: début-fin)");
+                    }
+
+                    if (!int.TryParse(rangeParts[0].Trim(), out var start) || 
+                        !int.TryParse(rangeParts[1].Trim(), out var end))
+                    {
+                        return (false, new List<int>(), $"Nombres invalides dans la plage : '{trimmed}'");
+                    }
+
+                    if (start > end)
+                    {
+                        return (false, new List<int>(), $"Plage invalide : {start} > {end}");
+                    }
+
+                    for (int i = start; i <= end; i++)
+                    {
+                        result.Add(i);
+                    }
+                }
+                else
+                {
+                    // Single number
+                    if (!int.TryParse(trimmed, out var number))
+                    {
+                        return (false, new List<int>(), $"Nombre invalide : '{trimmed}'");
+                    }
+                    result.Add(number);
+                }
+            }
+
+            if (result.Count == 0)
+            {
+                return (false, new List<int>(), "Aucun numéro de ligne spécifié");
+            }
+
+            return (true, result.OrderBy(n => n).ToList(), string.Empty);
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            var input = RangesText.Text.Trim();
+            var (success, numbers, error) = ParseInput(input);
+
+            if (!success)
+            {
+                MessageBox.Show(error, "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            SelectedNumbers = numbers;
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/TapisT13Window.xaml
+++ b/Ploco/Dialogs/TapisT13Window.xaml
@@ -4,6 +4,16 @@
         Title="Tapis T13" Height="520" Width="680"
         WindowStartupLocation="CenterOwner">
     <Grid Margin="12">
+        <Grid.Resources>
+            <Style x:Key="HsCellStyle" TargetType="DataGridCell">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsHs}" Value="True">
+                        <Setter Property="Background" Value="#FFD32F2F"/>
+                        <Setter Property="Foreground" Value="White"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -39,9 +49,10 @@
                   CanUserSortColumns="True">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Locomotive" Binding="{Binding Locomotive}" Width="*"/>
+                <DataGridTextColumn Header="Date entretien" Binding="{Binding MaintenanceDate}" Width="*"/>
                 <DataGridTextColumn Header="Statut / Motif" Binding="{Binding Motif}" Width="*"/>
-                <DataGridTextColumn Header="Loc HS" Binding="{Binding LocHs}" Width="*"/>
-                <DataGridTextColumn Header="Infos / Rapport" Binding="{Binding Report}" Width="*"/>
+                <DataGridTextColumn Header="Loc HS" Binding="{Binding LocHs}" Width="*" CellStyle="{StaticResource HsCellStyle}"/>
+                <DataGridTextColumn Header="Infos / Rapport" Binding="{Binding Report}" Width="*" CellStyle="{StaticResource HsCellStyle}"/>
             </DataGrid.Columns>
         </DataGrid>
 

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -34,6 +34,7 @@ namespace Ploco.Dialogs
             {
                 var track = tracks.FirstOrDefault(t => t.Locomotives.Contains(loco));
                 var location = ResolveLocation(track, tiles);
+                var rollingLineNumber = ResolveRollingLineNumber(track);
                 var trainInfo = track?.IsOnTrain == true
                     ? string.IsNullOrWhiteSpace(track.TrainNumber)
                         ? location
@@ -42,12 +43,15 @@ namespace Ploco.Dialogs
 
                 var isHs = loco.Status == LocomotiveStatus.HS;
                 var locHs = isHs ? trainInfo : string.Empty;
-                var report = isHs ? trainInfo : string.Empty;
+                var report = !string.IsNullOrWhiteSpace(rollingLineNumber)
+                    ? rollingLineNumber
+                    : isHs ? trainInfo : string.Empty;
                 var motif = isHs ? (loco.HsReason ?? string.Empty) : string.Empty;
 
                 _rows.Add(new T13Row
                 {
                     Locomotive = loco.Number.ToString(),
+                    MaintenanceDate = loco.MaintenanceDate ?? string.Empty,
                     Motif = motif,
                     LocHs = locHs,
                     Report = report,
@@ -78,6 +82,16 @@ namespace Ploco.Dialogs
             }
 
             return GetLocationAbbreviation(tile.Name);
+        }
+
+        private static string ResolveRollingLineNumber(TrackModel? track)
+        {
+            if (track?.Kind != TrackKind.RollingLine)
+            {
+                return string.Empty;
+            }
+
+            return track.Name;
         }
 
         private static string GetLocationAbbreviation(string name)
@@ -166,6 +180,7 @@ namespace Ploco.Dialogs
         private sealed class T13Row
         {
             public string Locomotive { get; set; } = string.Empty;
+            public string MaintenanceDate { get; set; } = string.Empty;
             public string Motif { get; set; } = string.Empty;
             public string LocHs { get; set; } = string.Empty;
             public string Report { get; set; } = string.Empty;

--- a/Ploco/Helpers/TileTemplateSelector.cs
+++ b/Ploco/Helpers/TileTemplateSelector.cs
@@ -9,6 +9,7 @@ namespace Ploco.Helpers
         public DataTemplate? DepotTemplate { get; set; }
         public DataTemplate? GarageTemplate { get; set; }
         public DataTemplate? LineTemplate { get; set; }
+        public DataTemplate? RollingLineTemplate { get; set; }
 
         public override DataTemplate? SelectTemplate(object item, DependencyObject container)
         {
@@ -22,6 +23,7 @@ namespace Ploco.Helpers
                 TileType.Depot => DepotTemplate,
                 TileType.VoieGarage => GarageTemplate,
                 TileType.ArretLigne => LineTemplate,
+                TileType.RollingLine => RollingLineTemplate,
                 _ => base.SelectTemplate(item, container)
             };
         }

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -828,6 +828,8 @@
             <MenuItem Header="Tapis">
                 <MenuItem Header="T13" Click="MenuItem_TapisT13_Click"/>
                 <MenuItem Header="37000" IsEnabled="False"/>
+                <Separator/>
+                <MenuItem Header="Planning PDF" Click="MenuItem_PlanningPdf_Click"/>
             </MenuItem>
             <MenuItem Header="Vue">
                 <MenuItem Header="Charger un preset" x:Name="ViewPresetsMenu"/>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -689,10 +689,111 @@
                 </Grid>
             </Border>
         </DataTemplate>
+        <DataTemplate x:Key="RollingLineTileTemplate">
+            <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="220"
+                    AllowDrop="True"
+                    Drop="Tile_Drop"
+                    MouseLeftButtonDown="Tile_MouseLeftButtonDown"
+                    MouseMove="Tile_MouseMove"
+                    MouseLeftButtonUp="Tile_MouseLeftButtonUp">
+                <Grid>
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding DisplayTitle}" FontWeight="Bold" FontSize="14"/>
+                            <Menu Grid.Column="1" HorizontalAlignment="Right">
+                                <MenuItem Header="...">
+                                    <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Ajouter une ligne" Click="AddRollingLineTrack_Click" Tag="{Binding}"/>
+                                </MenuItem>
+                            </Menu>
+                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding RollingLineTracks}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                                <Grid Margin="0,4,0,0">
+                                                    <ListBox x:Name="RollingLineTrackList"
+                                                             ItemsSource="{Binding Locomotives}"
+                                                             Style="{StaticResource DropListBoxStyle}"
+                                                             AllowDrop="True"
+                                                             PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
+                                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
+                                                             Drop="TrackLocomotives_Drop">
+                                                        <ListBox.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
+                                                                        Padding="4" Margin="2" CornerRadius="4"
+                                                                        ContextMenu="{StaticResource LocomotiveTileContextMenu}"
+                                                                        PreviewMouseRightButtonDown="LocomotiveItem_PreviewMouseRightButtonDown">
+                                                                    <Grid>
+                                                                        <Grid.RowDefinitions>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                        </Grid.RowDefinitions>
+                                                                        <TextBlock Grid.Row="0" Text="{Binding Number}" Foreground="White" FontWeight="Bold" FontSize="12"
+                                                                                   HorizontalAlignment="Left"/>
+                                                                        <TextBlock Grid.Row="1" Text="{Binding TractionDisplay}" FontSize="10" Foreground="White"
+                                                                                   HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                                            <TextBlock.Style>
+                                                                                <Style TargetType="TextBlock">
+                                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                                    <Style.Triggers>
+                                                                                        <DataTrigger Binding="{Binding TractionDisplay}" Value="">
+                                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                        </DataTrigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </TextBlock.Style>
+                                                                        </TextBlock>
+                                                                    </Grid>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ListBox.ItemTemplate>
+                                                    </ListBox>
+                                                    <TextBlock Text="Déposez ici" Foreground="SlateGray" FontStyle="Italic"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding ElementName=RollingLineTrackList, Path=HasItems}" Value="False">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Grid>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                        <Button Content="Ajouter une ligne" Margin="0,6,0,0" HorizontalAlignment="Right"
+                                Click="AddRollingLineTrack_Click" Tag="{Binding}"/>
+                    </StackPanel>
+                    <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                           Cursor="SizeNWSE" DragDelta="TileResizeThumb_DragDelta" DragCompleted="TileResizeThumb_DragCompleted"
+                           Background="#55000000" BorderBrush="#FF7A7A7A" BorderThickness="1"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
         <helpers:TileTemplateSelector x:Key="TileTemplateSelector"
                                     DepotTemplate="{StaticResource DepotTileTemplate}"
                                     GarageTemplate="{StaticResource GarageTileTemplate}"
-                                    LineTemplate="{StaticResource LineTileTemplate}"/>
+                                    LineTemplate="{StaticResource LineTileTemplate}"
+                                    RollingLineTemplate="{StaticResource RollingLineTileTemplate}"/>
     </Window.Resources>
     <DockPanel>
         <Menu DockPanel.Dock="Top">

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -32,6 +32,12 @@
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
             <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         </Style>
+        <Style x:Key="RollingLineDropListStyle" TargetType="ListBox" BasedOn="{StaticResource DropListBoxStyle}">
+            <Setter Property="MinHeight" Value="28"/>
+            <Setter Property="MinWidth" Value="160"/>
+            <Setter Property="Padding" Value="2"/>
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled"/>
+        </Style>
         <Style TargetType="ListBox">
             <Setter Property="Background" Value="{DynamicResource ListBackgroundBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource ListBorderBrush}"/>
@@ -691,7 +697,7 @@
         </DataTemplate>
         <DataTemplate x:Key="RollingLineTileTemplate">
             <Border Background="{DynamicResource TileBackgroundBrush}" BorderBrush="{DynamicResource TileBorderBrush}" BorderThickness="1"
-                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="220"
+                    CornerRadius="6" Padding="8" Width="{Binding Width}" Height="{Binding Height}" MinWidth="260" MinHeight="200"
                     AllowDrop="True"
                     Drop="Tile_Drop"
                     MouseLeftButtonDown="Tile_MouseLeftButtonDown"
@@ -718,17 +724,27 @@
                             <ItemsControl ItemsSource="{Binding RollingLineTracks}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="6" Margin="0,6,0,6">
-                                            <StackPanel>
-                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                                                <Grid Margin="0,4,0,0">
+                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="4" Margin="0,2,0,2">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="48"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                <Grid Grid.Column="1">
                                                     <ListBox x:Name="RollingLineTrackList"
                                                              ItemsSource="{Binding Locomotives}"
-                                                             Style="{StaticResource DropListBoxStyle}"
+                                                             Style="{StaticResource RollingLineDropListStyle}"
                                                              AllowDrop="True"
+                                                             HorizontalAlignment="Stretch"
                                                              PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
                                                              PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
                                                              Drop="TrackLocomotives_Drop">
+                                                        <ListBox.ItemsPanel>
+                                                            <ItemsPanelTemplate>
+                                                                <WrapPanel Orientation="Horizontal"/>
+                                                            </ItemsPanelTemplate>
+                                                        </ListBox.ItemsPanel>
                                                         <ListBox.ItemTemplate>
                                                             <DataTemplate>
                                                                 <Border Background="{Binding Status, Converter={StaticResource StatutToBrushConverter}}"
@@ -774,7 +790,7 @@
                                                         </TextBlock.Style>
                                                     </TextBlock>
                                                 </Grid>
-                                            </StackPanel>
+                                            </Grid>
                                         </Border>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
@@ -889,7 +905,10 @@
                 </DockPanel>
             </Border>
             <Border Grid.Column="1" Margin="10" Background="{DynamicResource CanvasBackgroundBrush}" CornerRadius="6">
-                <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                <ScrollViewer x:Name="TileScrollViewer"
+                              HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Auto"
+                              PanningMode="Both">
                     <ItemsControl x:Name="TileCanvas">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -908,7 +908,8 @@
                 <ScrollViewer x:Name="TileScrollViewer"
                               HorizontalScrollBarVisibility="Auto"
                               VerticalScrollBarVisibility="Auto"
-                              PanningMode="Both">
+                              PanningMode="Both"
+                              SizeChanged="TileScrollViewer_SizeChanged">
                     <ItemsControl x:Name="TileCanvas">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -34,7 +34,7 @@
         </Style>
         <Style x:Key="RollingLineDropListStyle" TargetType="ListBox" BasedOn="{StaticResource DropListBoxStyle}">
             <Setter Property="MinHeight" Value="28"/>
-            <Setter Property="MinWidth" Value="160"/>
+            <Setter Property="MinWidth" Value="110"/>
             <Setter Property="Padding" Value="2"/>
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled"/>
         </Style>
@@ -716,7 +716,7 @@
                                     <MenuItem Header="Renommer tuile" Click="RenameTile_Click" Tag="{Binding}"/>
                                     <MenuItem Header="Supprimer tuile" Click="DeleteTile_Click" Tag="{Binding}"/>
                                     <Separator/>
-                                    <MenuItem Header="Ajouter une ligne" Click="AddRollingLineTrack_Click" Tag="{Binding}"/>
+                                    <MenuItem Header="Configurer lignes" Click="AddRollingLineTrack_Click" Tag="{Binding}"/>
                                 </MenuItem>
                             </Menu>
                         </Grid>
@@ -724,22 +724,26 @@
                             <ItemsControl ItemsSource="{Binding RollingLineTracks}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="4" Margin="0,2,0,2">
+                                        <Border BorderBrush="{DynamicResource TrackBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="3" Margin="0,2,0,2"
+                                                AllowDrop="True"
+                                                Background="Transparent"
+                                                DragOver="RollingLineRow_DragOver"
+                                                DragLeave="RollingLineRow_DragLeave"
+                                                Drop="RollingLineRow_Drop">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="48"/>
-                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="40"/>
+                                                    <ColumnDefinition Width="Auto"/>
                                                 </Grid.ColumnDefinitions>
                                                 <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                                 <Grid Grid.Column="1">
                                                     <ListBox x:Name="RollingLineTrackList"
                                                              ItemsSource="{Binding Locomotives}"
                                                              Style="{StaticResource RollingLineDropListStyle}"
-                                                             AllowDrop="True"
-                                                             HorizontalAlignment="Stretch"
+                                                             AllowDrop="False"
+                                                             HorizontalAlignment="Left"
                                                              PreviewMouseLeftButtonDown="TrackLocomotives_PreviewMouseLeftButtonDown"
-                                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove"
-                                                             Drop="TrackLocomotives_Drop">
+                                                             PreviewMouseMove="TrackLocomotives_PreviewMouseMove">
                                                         <ListBox.ItemsPanel>
                                                             <ItemsPanelTemplate>
                                                                 <WrapPanel Orientation="Horizontal"/>
@@ -796,7 +800,7 @@
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
                         </ScrollViewer>
-                        <Button Content="Ajouter une ligne" Margin="0,6,0,0" HorizontalAlignment="Right"
+                        <Button Content="Configurer lignes" Margin="0,6,0,0" HorizontalAlignment="Right"
                                 Click="AddRollingLineTrack_Click" Tag="{Binding}"/>
                     </StackPanel>
                     <Thumb Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom"

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -1466,38 +1466,6 @@ namespace Ploco
             tile.RefreshTrackCollections();
         }
 
-        private static int EnsureRollingLineCountWithinAssignments(TileModel tile, List<int> requestedNumbers)
-        {
-            var assignedNumbers = tile.Tracks
-                .Where(t => t.Kind == TrackKind.RollingLine && t.Locomotives.Any())
-                .Select(t => int.TryParse(t.Name, out var value) ? value : 0)
-                .Where(value => value > 0)
-                .ToList();
-
-            if (!assignedNumbers.Any())
-            {
-                return requestedNumbers.Count;
-            }
-
-            var maxAssigned = assignedNumbers.Max();
-            var minAssigned = assignedNumbers.Min();
-            
-            // Check if all assigned numbers are included in the requested numbers
-            if (assignedNumbers.All(n => requestedNumbers.Contains(n)))
-            {
-                return requestedNumbers.Count;
-            }
-
-            // Need to expand to include all assigned numbers
-            var expandedNumbers = new HashSet<int>(requestedNumbers);
-            foreach (var assigned in assignedNumbers)
-            {
-                expandedNumbers.Add(assigned);
-            }
-
-            return expandedNumbers.Count;
-        }
-
         private static List<int> EnsureRollingLineNumbersWithinAssignments(TileModel tile, List<int> requestedNumbers)
         {
             var assignedNumbers = tile.Tracks
@@ -1523,7 +1491,7 @@ namespace Ploco
 
         private static string FormatRollingLineRange(List<int> numbers)
         {
-            if (numbers.Count == 0)
+            if (numbers == null || numbers.Count == 0)
             {
                 return "";
             }

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -1177,6 +1177,11 @@ namespace Ploco
             OpenModelessWindow(() => new TapisT13Window(_locomotives, _tiles));
         }
 
+        private void MenuItem_PlanningPdf_Click(object sender, RoutedEventArgs e)
+        {
+            OpenModelessWindow(() => new PlanningPdfWindow(_repository));
+        }
+
         private void MenuItem_DatabaseManagement_Click(object sender, RoutedEventArgs e)
         {
             OpenModelessWindow(() => new DatabaseManagementWindow(_repository, _locomotives, _tiles));

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace Ploco
         private const string LayoutPresetFileName = "layout_presets.json";
         private const double MinTileWidth = 260;
         private const double MinTileHeight = 180;
+        private const double CanvasPadding = 80;
         private bool _isDarkMode;
         private Point _dragStartPoint;
         private TileModel? _draggedTile;
@@ -55,6 +56,7 @@ namespace Ploco
             LocomotiveList.ItemsSource = _locomotives;
             TileCanvas.ItemsSource = _tiles;
             InitializeLocomotiveView();
+            UpdateTileCanvasExtent();
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -91,6 +93,7 @@ namespace Ploco
             }
 
             UpdatePoolVisibility();
+            UpdateTileCanvasExtent();
         }
 
         private void PersistState()
@@ -183,6 +186,7 @@ namespace Ploco
             _tiles.Add(tile);
             _repository.AddHistory("TileCreated", $"Création du lieu {tile.DisplayTitle}.");
             PersistState();
+            UpdateTileCanvasExtent();
         }
 
         private void AddLineTile(LinePlaceDialog dialog)
@@ -284,6 +288,7 @@ namespace Ploco
 
             UpdatePoolVisibility();
             PersistState();
+            UpdateTileCanvasExtent();
         }
 
         private void AddRollingLineTile(string name)
@@ -310,6 +315,7 @@ namespace Ploco
             _repository.AddHistory("TileCreated", $"Création du lieu {tile.DisplayTitle}.");
             _repository.AddHistory("RollingLineAdded", $"Lignes 1101 à 1123 ajoutées dans {tile.DisplayTitle}.");
             PersistState();
+            UpdateTileCanvasExtent();
         }
 
         private void DeleteTile_Click(object sender, RoutedEventArgs e)
@@ -332,6 +338,7 @@ namespace Ploco
             _repository.AddHistory("TileDeleted", $"Suppression du lieu {tile.DisplayTitle}.");
             UpdatePoolVisibility();
             PersistState();
+            UpdateTileCanvasExtent();
         }
 
         private void RenameTile_Click(object sender, RoutedEventArgs e)
@@ -502,6 +509,7 @@ namespace Ploco
             tile.RefreshTrackCollections();
             _repository.AddHistory("RollingLineAdded", $"Ajout de la ligne {track.Name} dans {tile.DisplayTitle}.");
             PersistState();
+            UpdateTileCanvasExtent();
         }
 
         private void RemoveLineTrack_Click(object sender, RoutedEventArgs e)
@@ -1055,6 +1063,7 @@ namespace Ploco
             _draggedTile.X = Math.Max(0, _draggedTile.X + offset.X);
             _draggedTile.Y = Math.Max(0, _draggedTile.Y + offset.Y);
             _tileDragStart = currentPosition;
+            UpdateTileCanvasExtent();
         }
 
         private void Tile_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
@@ -1064,6 +1073,7 @@ namespace Ploco
                 ResolveTileOverlap(_draggedTile);
                 _repository.AddHistory("TileMoved", $"Tuile {_draggedTile.Name} déplacée.");
                 PersistState();
+                UpdateTileCanvasExtent();
             }
             if (sender is Border border)
             {
@@ -1079,6 +1089,7 @@ namespace Ploco
                 _isResizingTile = true;
                 tile.Width = Math.Max(MinTileWidth, tile.Width + e.HorizontalChange);
                 tile.Height = Math.Max(MinTileHeight, tile.Height + e.VerticalChange);
+                UpdateTileCanvasExtent();
             }
         }
 
@@ -1090,6 +1101,7 @@ namespace Ploco
                 ResolveTileOverlap(tile);
                 _repository.AddHistory("TileResized", $"Tuile {tile.Name} redimensionnée.");
                 PersistState();
+                UpdateTileCanvasExtent();
             }
         }
 
@@ -1805,6 +1817,27 @@ namespace Ploco
                 tile.RefreshTrackCollections();
                 _tiles.Add(tile);
             }
+            UpdateTileCanvasExtent();
+        }
+
+        private void UpdateTileCanvasExtent()
+        {
+            if (TileCanvas == null)
+            {
+                return;
+            }
+
+            if (!_tiles.Any())
+            {
+                TileCanvas.Width = 0;
+                TileCanvas.Height = 0;
+                return;
+            }
+
+            var maxX = _tiles.Max(tile => tile.X + tile.Width);
+            var maxY = _tiles.Max(tile => tile.Y + tile.Height);
+            TileCanvas.Width = Math.Max(0, maxX + CanvasPadding);
+            TileCanvas.Height = Math.Max(0, maxY + CanvasPadding);
         }
 
         private static JsonSerializerOptions GetPresetSerializerOptions()

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -419,6 +419,20 @@ namespace Ploco.Models
 
         public string? LocationPreset { get; set; }
         public int? GarageTrackNumber { get; set; }
+        private int? _rollingLineCount;
+
+        public int? RollingLineCount
+        {
+            get => _rollingLineCount;
+            set
+            {
+                if (_rollingLineCount != value)
+                {
+                    _rollingLineCount = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         public double X
         {

--- a/Ploco/Models/DomainModels.cs
+++ b/Ploco/Models/DomainModels.cs
@@ -17,7 +17,8 @@ namespace Ploco.Models
     {
         Depot,
         ArretLigne,
-        VoieGarage
+        VoieGarage,
+        RollingLine
     }
 
     public enum TrackKind
@@ -25,7 +26,8 @@ namespace Ploco.Models
         Main,
         Output,
         Zone,
-        Line
+        Line,
+        RollingLine
     }
 
     public class RollingStockSeries
@@ -42,6 +44,7 @@ namespace Ploco.Models
         private LocomotiveStatus _status;
         private int? _tractionPercent;
         private string? _hsReason;
+        private string? _maintenanceDate;
         private double? _assignedTrackOffsetX;
         private int? _assignedTrackId;
         private bool _isVisibleInActivePool = true;
@@ -87,6 +90,19 @@ namespace Ploco.Models
                 if (_hsReason != value)
                 {
                     _hsReason = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string? MaintenanceDate
+        {
+            get => _maintenanceDate;
+            set
+            {
+                if (_maintenanceDate != value)
+                {
+                    _maintenanceDate = value;
                     OnPropertyChanged();
                 }
             }
@@ -368,6 +384,7 @@ namespace Ploco.Models
         private readonly ObservableCollection<TrackModel> _outputTracks = new();
         private readonly ObservableCollection<TrackModel> _zoneTracks = new();
         private readonly ObservableCollection<TrackModel> _lineTracks = new();
+        private readonly ObservableCollection<TrackModel> _rollingLineTracks = new();
 
         public int Id { get; set; }
         private TileType _type;
@@ -459,6 +476,7 @@ namespace Ploco.Models
         public ObservableCollection<TrackModel> OutputTracks => _outputTracks;
         public ObservableCollection<TrackModel> ZoneTracks => _zoneTracks;
         public ObservableCollection<TrackModel> LineTracks => _lineTracks;
+        public ObservableCollection<TrackModel> RollingLineTracks => _rollingLineTracks;
 
         public string DisplayTitle
         {
@@ -479,6 +497,7 @@ namespace Ploco.Models
             _outputTracks.Clear();
             _zoneTracks.Clear();
             _lineTracks.Clear();
+            _rollingLineTracks.Clear();
 
             foreach (var track in Tracks)
             {
@@ -492,6 +511,9 @@ namespace Ploco.Models
                         break;
                     case TrackKind.Line:
                         _lineTracks.Add(track);
+                        break;
+                    case TrackKind.RollingLine:
+                        _rollingLineTracks.Add(track);
                         break;
                 }
             }

--- a/Ploco/Models/PdfPlanningModels.cs
+++ b/Ploco/Models/PdfPlanningModels.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ploco.Models
+{
+    public class PdfDocumentModel
+    {
+        public int Id { get; set; }
+        public string FilePath { get; set; } = string.Empty;
+        public DateTime DocumentDate { get; set; }
+        public string TemplateHash { get; set; } = string.Empty;
+        public int PageCount { get; set; }
+    }
+
+    public class PdfTemplateCalibrationModel
+    {
+        public int Id { get; set; }
+        public string TemplateHash { get; set; } = string.Empty;
+        public int PageIndex { get; set; }
+        public double XStart { get; set; }
+        public double XEnd { get; set; }
+        public List<PdfTemplateRowMapping> Rows { get; set; } = new();
+    }
+
+    public class PdfTemplateRowMapping
+    {
+        public int Id { get; set; }
+        public int CalibrationId { get; set; }
+        public string RoulementId { get; set; } = string.Empty;
+        public double YCenter { get; set; }
+    }
+
+    public class PdfPlacementModel
+    {
+        public int Id { get; set; }
+        public int PdfDocumentId { get; set; }
+        public int PageIndex { get; set; }
+        public string RoulementId { get; set; } = string.Empty;
+        public int MinuteOfDay { get; set; }
+        public int LocNumber { get; set; }
+        public LocomotiveStatus Status { get; set; }
+        public int? TractionPercent { get; set; }
+        public int? MotorsHsCount { get; set; }
+        public string? HsReason { get; set; }
+        public bool OnTrain { get; set; }
+        public string? TrainNumber { get; set; }
+        public string? TrainStopTime { get; set; }
+        public string? Comment { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/Ploco/Models/PdfPlanningModels.cs
+++ b/Ploco/Models/PdfPlanningModels.cs
@@ -12,6 +12,12 @@ namespace Ploco.Models
         public int PageCount { get; set; }
     }
 
+    public enum CalibrationLineType
+    {
+        Horizontal,  // Ligne de roulement
+        Vertical     // Marqueur d'heure
+    }
+
     public class PdfTemplateCalibrationModel
     {
         public int Id { get; set; }
@@ -20,6 +26,17 @@ namespace Ploco.Models
         public double XStart { get; set; }
         public double XEnd { get; set; }
         public List<PdfTemplateRowMapping> Rows { get; set; } = new();
+        public List<PdfCalibrationLine> VisualLines { get; set; } = new();
+    }
+
+    public class PdfCalibrationLine
+    {
+        public int Id { get; set; }
+        public int CalibrationId { get; set; }
+        public CalibrationLineType Type { get; set; }
+        public double Position { get; set; }  // X pour vertical, Y pour horizontal (coordonnées PDF)
+        public string Label { get; set; } = string.Empty;  // Ex: "06:00" ou "@1101"
+        public int? MinuteOfDay { get; set; }  // Pour lignes verticales (heures)
     }
 
     public class PdfTemplateRowMapping

--- a/Ploco/Ploco.csproj
+++ b/Ploco/Ploco.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
-    <PackageReference Include="UglyToad.PdfPig" Version="0.1.9-alpha001-patch1" />
+    <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
     <PackageReference Include="UglyToad.PdfPig.Core" Version="1.7.0-custom-5" />
     <PackageReference Include="UglyToad.PdfPig.Fonts" Version="1.7.0-custom-5" />
     <PackageReference Include="UglyToad.PdfPig.Tokenization" Version="1.7.0-custom-5" />

--- a/Ploco/Ploco.csproj
+++ b/Ploco/Ploco.csproj
@@ -25,6 +25,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
     <PackageReference Include="UglyToad.PdfPig" Version="0.1.9-alpha001-patch1" />
+    <PackageReference Include="UglyToad.PdfPig.Core" Version="1.7.0-custom-5" />
+    <PackageReference Include="UglyToad.PdfPig.Fonts" Version="1.7.0-custom-5" />
+    <PackageReference Include="UglyToad.PdfPig.Tokenization" Version="1.7.0-custom-5" />
+    <PackageReference Include="UglyToad.PdfPig.Tokens" Version="1.7.0-custom-5" />
     <PackageReference Include="Docnet.Core" Version="2.3.0" />
     <PackageReference Include="PdfSharpCore" Version="1.3.47" />
   </ItemGroup>

--- a/Ploco/Ploco.csproj
+++ b/Ploco/Ploco.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
-    <PackageReference Include="UglyToad.PdfPig" Version="0.0.10" />
+    <PackageReference Include="UglyToad.PdfPig" Version="0.1.9-alpha001-patch1" />
     <PackageReference Include="Docnet.Core" Version="2.3.0" />
     <PackageReference Include="PdfSharpCore" Version="1.3.47" />
   </ItemGroup>

--- a/Ploco/Ploco.csproj
+++ b/Ploco/Ploco.csproj
@@ -24,6 +24,9 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
+    <PackageReference Include="UglyToad.PdfPig" Version="0.0.10" />
+    <PackageReference Include="Docnet.Core" Version="2.3.0" />
+    <PackageReference Include="PdfSharpCore" Version="1.3.47" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ploco/Ploco.csproj
+++ b/Ploco/Ploco.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>img\train_logo.ico</ApplicationIcon>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Provide a new tile type for managing numbered "lignes de roulement" (1101–1123) where each line hosts at most one locomotive. 
- Allow users to create and extend rolling-line lists from the UI and keep assignments persistent. 
- Surface rolling-line numbers and a maintenance-date field in the T13 report and visually highlight HS locomotives. 

### Description
- Introduced `TileType.RollingLine` and `TrackKind.RollingLine` and added `RollingLineTracks` collections and plumbing in `TileModel`/`TrackModel` to enumerate and render rolling-line tracks. 
- Added a new option in the "Ajouter un lieu" dialog and a `RollingLineTileTemplate` in `MainWindow.xaml` to create a rolling-line tile and to display its lines; implemented `AddRollingLineTile` to initialize lines 1101–1123 and `AddRollingLineTrack_Click` to add additional numbered lines (auto-suggests next number with validation). 
- Enforced single-locomotive-per-rolling-line at drop-time and when moving locomotives (`TrackLocomotives_Drop` and `MoveLocomotiveToTrack`), and updated default drop selection to prefer empty rolling lines. 
- Persisted a new `maintenance_date` column for locomotives in the database and wired read/write into `PlocoRepository` and `LocomotiveModel` (`MaintenanceDate`). 
- Extended the T13 window (`TapisT13Window`) to include a "Date entretien" column, display rolling-line number in the report column when applicable, and apply a red cell style for HS rows in the "Loc HS" and "Infos / Rapport" columns. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981b8a2cd408331b568a038907966bc)