### PR TITLE
Release V1.0.8 : Stabilisation du workflow ATE, prévisionnel et correction de bugs graphiques

### DIFF
--- a/Ploco/Dialogs/DialogService.cs
+++ b/Ploco/Dialogs/DialogService.cs
@@ -70,10 +70,23 @@ namespace Ploco.Dialogs
             return dialog.ShowDialog() == true ? dialog.SelectedTrack : null;
         }
 
+        public TrackModel? ShowTargetTrackSelectionDialog(IEnumerable<TileModel> tiles)
+        {
+            var dialog = new TargetTrackSelectionDialog(tiles) { Owner = Owner };
+            return dialog.ShowDialog() == true ? dialog.SelectedTrack : null;
+        }
+
         public List<int>? ShowRollingLineRangeDialog(int defaultCount)
         {
             var dialog = new RollingLineRangeDialog(defaultCount.ToString()) { Owner = Owner };
             return dialog.ShowDialog() == true ? dialog.SelectedNumbers : null;
+        }
+
+        public ReplaceAction ShowReplaceLocomotiveDialog(string targetTrackName, string existingLocoNumber)
+        {
+            var dialog = new ReplaceLocomotiveDialog(targetTrackName, existingLocoNumber) { Owner = Owner };
+            dialog.ShowDialog();
+            return dialog.SelectedAction;
         }
     }
 }

--- a/Ploco/Dialogs/IDialogService.cs
+++ b/Ploco/Dialogs/IDialogService.cs
@@ -5,6 +5,13 @@ namespace Ploco.Dialogs
 {
     public record LinePlaceDialogResult(string PlaceName, string TrackName, string IssueReason, bool IsOnTrain, string TrainNumber, string StopTime, bool IsLocomotiveHs, string HsLocomotiveNumbers, string LocomotiveNumbers);
 
+    public enum ReplaceAction
+    {
+        Cancel,
+        Swap,
+        Pool
+    }
+
     public interface IDialogService
     {
         bool ShowConfirmation(string title, string message);
@@ -17,6 +24,8 @@ namespace Ploco.Dialogs
         (bool success, LinePlaceDialogResult? result) ShowLinePlaceDialog(string defaultName);
         (bool success, TrackModel? track) ShowLineTrackDialog();
         TrackModel? ShowRollingLineSelectionDialog(IEnumerable<TileModel> tiles);
+        TrackModel? ShowTargetTrackSelectionDialog(IEnumerable<TileModel> tiles);
         List<int>? ShowRollingLineRangeDialog(int defaultCount);
+        ReplaceAction ShowReplaceLocomotiveDialog(string targetTrackName, string existingLocoNumber);
     }
 }

--- a/Ploco/Dialogs/ReplaceLocomotiveDialog.xaml
+++ b/Ploco/Dialogs/ReplaceLocomotiveDialog.xaml
@@ -1,0 +1,20 @@
+<Window x:Class="Ploco.Dialogs.ReplaceLocomotiveDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Ligne occupée" Height="150" Width="450"
+        WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+    <Grid Margin="15">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock x:Name="MessageTextBlock" TextWrapping="Wrap" FontSize="14" VerticalAlignment="Center" Margin="0,0,0,20"/>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Croiser (Swap)" Width="110" Height="30" Margin="0,0,10,0" Click="Swap_Click" />
+            <Button Content="Tiroir (Pool)" Width="110" Height="30" Margin="0,0,10,0" Click="Pool_Click" />
+            <Button Content="Annuler" Width="100" Height="30" Click="Cancel_Click" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/ReplaceLocomotiveDialog.xaml.cs
+++ b/Ploco/Dialogs/ReplaceLocomotiveDialog.xaml.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+
+namespace Ploco.Dialogs
+{
+    public partial class ReplaceLocomotiveDialog : Window
+    {
+        public ReplaceAction SelectedAction { get; private set; } = ReplaceAction.Cancel;
+
+        public ReplaceLocomotiveDialog(string targetTrackName, string existingLocoNumber)
+        {
+            InitializeComponent();
+            MessageTextBlock.Text = $"La ligne {targetTrackName} est occupée par la locomotive {existingLocoNumber}.\nQue voulez-vous faire ?";
+        }
+
+        private void Swap_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedAction = ReplaceAction.Swap;
+            DialogResult = true;
+        }
+
+        private void Pool_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedAction = ReplaceAction.Pool;
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedAction = ReplaceAction.Cancel;
+            DialogResult = false;
+        }
+    }
+}

--- a/Ploco/Dialogs/TapisT13Window.xaml.cs
+++ b/Ploco/Dialogs/TapisT13Window.xaml.cs
@@ -44,8 +44,8 @@ namespace Ploco.Dialogs
 
                 if (ghostTrack != null)
                 {
-                    string originStr = GetLocationTextForTrack(loco, realTrack, tiles);
-                    string targetStr = GetLocationTextForTrack(loco, ghostTrack, tiles);
+                    string originStr = GetLocationTextForTrack(loco, realTrack, tiles, false);
+                    string targetStr = GetLocationTextForTrack(loco, ghostTrack, tiles, true);
                     report = $"{originStr} + {targetStr}";
                     locHs = isHs ? report : string.Empty;
 
@@ -99,11 +99,11 @@ namespace Ploco.Dialogs
             UpdateSummary();
         }
         
-        private static string GetLocationTextForTrack(LocomotiveModel loco, TrackModel? track, IEnumerable<TileModel> tiles)
+        private static string GetLocationTextForTrack(LocomotiveModel loco, TrackModel? track, IEnumerable<TileModel> tiles, bool isForecastTarget)
         {
             if (track == null) return string.Empty;
             if (track.Kind == TrackKind.RollingLine) return track.Name;
-            return GetTrainLocationText(loco, track, tiles);
+            return GetTrainLocationText(loco, track, tiles, isForecastTarget);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Ploco.Dialogs
         /// Gets the train location text for a locomotive.
         /// Handles different track kinds and locomotive statuses.
         /// </summary>
-        private static string GetTrainLocationText(LocomotiveModel loco, TrackModel? track, IEnumerable<TileModel> tiles)
+        private static string GetTrainLocationText(LocomotiveModel loco, TrackModel? track, IEnumerable<TileModel> tiles, bool isForecastTarget = false)
         {
             if (track == null)
             {
@@ -146,6 +146,14 @@ namespace Ploco.Dialogs
                 return $"{location} {track.TrainNumber}";
             }
             
+            // Règle automatique: si la voie est ATE,
+            // Prévisionnel : "ATE"
+            // Physique : "FNND" (l'abréviation de la tuile, location)
+            if (track.Name.Equals("ATE", StringComparison.OrdinalIgnoreCase))
+            {
+                return isForecastTarget ? track.Name.ToUpper() : location;
+            }
+
             // For OK locomotives in depot/garage (not Line, not RollingLine): "DISPO TileName"
             if (loco.Status == LocomotiveStatus.Ok && 
                 track.Kind != TrackKind.Line && 
@@ -202,8 +210,8 @@ namespace Ploco.Dialogs
             {
                 "Thionville" => "THL",
                 "SRH" => "SRH",
-                "Anvers Nord" => "FN",
-                "Anvers" => "FN",
+                "Anvers Nord" => "FNND",
+                "Anvers" => "FNND",
                 "Mulhouse Nord" => "MUN",
                 "Mulhouse" => "MUN",
                 "Bale" => "BAL",

--- a/Ploco/Dialogs/TargetTrackSelectionDialog.xaml
+++ b/Ploco/Dialogs/TargetTrackSelectionDialog.xaml
@@ -1,0 +1,52 @@
+<Window x:Class="Ploco.Dialogs.TargetTrackSelectionDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Sélectionner une destination" Height="450" Width="500"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Sélectionnez une voie de destination sur le tapis :" FontWeight="SemiBold" Margin="0,0,0,8"/>
+
+        <ListBox Grid.Row="1" x:Name="TracksListBox" Margin="0,0,0,12" 
+                 SelectionMode="Single" MouseDoubleClick="ListBox_MouseDoubleClick">
+            <ListBox.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="0,8,0,4" FontSize="14" Opacity="0.8"/>
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </ListBox.GroupStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Margin="10,2,0,2">
+                        <TextBlock Text="{Binding TrackName}" FontWeight="SemiBold" Margin="0,0,8,0"/>
+                        <TextBlock Text="- Occupée" Foreground="Red" FontWeight="Bold" Margin="8,0,0,0">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsOccupied}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Valider" Width="80" Margin="0,0,6,0" Click="Validate_Click" IsDefault="True"/>
+            <Button Content="Annuler" Width="80" Click="Cancel_Click" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Ploco/Dialogs/TargetTrackSelectionDialog.xaml.cs
+++ b/Ploco/Dialogs/TargetTrackSelectionDialog.xaml.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Input;
+using Ploco.Models;
+
+namespace Ploco.Dialogs
+{
+    public partial class TargetTrackSelectionDialog : Window
+    {
+        public class TargetTrackItem
+        {
+            public TrackModel Track { get; set; } = null!;
+            public string TileName { get; set; } = string.Empty;
+            public string TrackName { get; set; } = string.Empty;
+            public bool IsOccupied { get; set; }
+        }
+
+        public TrackModel? SelectedTrack { get; private set; }
+
+        public TargetTrackSelectionDialog(IEnumerable<TileModel> tiles)
+        {
+            InitializeComponent();
+
+            var tracksList = new List<TargetTrackItem>();
+
+            foreach (var tile in tiles)
+            {
+                foreach (var track in tile.Tracks)
+                {
+                    // Exclure la voie technique "Locomotives" (TrackKind.Main) uniquement pour Ligne de roulement
+                    if (track.Kind == TrackKind.Main && tile.Type == TileType.RollingLine)
+                    {
+                        continue;
+                    }
+
+                    tracksList.Add(new TargetTrackItem
+                    {
+                        Track = track,
+                        TileName = tile.DisplayTitle,
+                        TrackName = string.IsNullOrWhiteSpace(track.Name) ? "Voie" : track.Name,
+                        IsOccupied = track.Locomotives.Any()
+                    });
+                }
+            }
+
+            // Tri
+            tracksList = tracksList.OrderBy(x => x.TileName).ThenBy(x => x.IsOccupied).ThenBy(x => x.TrackName).ToList();
+
+            ICollectionView collectionView = CollectionViewSource.GetDefaultView(tracksList);
+            collectionView.GroupDescriptions.Add(new PropertyGroupDescription("TileName"));
+
+            TracksListBox.ItemsSource = collectionView;
+            
+            if (tracksList.Any())
+            {
+                TracksListBox.SelectedIndex = 0;
+            }
+        }
+
+        private void Validate_Click(object sender, RoutedEventArgs e)
+        {
+            if (TracksListBox.SelectedItem is TargetTrackItem item)
+            {
+                SelectedTrack = item.Track;
+                DialogResult = true;
+            }
+            else
+            {
+                MessageBox.Show("Veuillez sélectionner une voie.", "Validation", 
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        private void ListBox_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (TracksListBox.SelectedItem is TargetTrackItem item)
+            {
+                SelectedTrack = item.Track;
+                DialogResult = true;
+            }
+        }
+    }
+}

--- a/Ploco/MainWindow.xaml
+++ b/Ploco/MainWindow.xaml
@@ -1,11 +1,11 @@
-﻿<Window x:Class="Ploco.MainWindow"
+<Window x:Class="Ploco.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Ploco.Converters"
         xmlns:helpers="clr-namespace:Ploco.Helpers"
         xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:Ploco.Behaviors"
-        Title="Ploc Manager - V1.0.7 Release - By LNK Services" Height="800" Width="1200"
+        Title="Ploc Manager - V1.0.8 Release - By LNK Services" Height="800" Width="1200"
         Icon="pack://application:,,,/img/train_logo.ico"
         Background="{DynamicResource AppBackgroundBrush}"
         Loaded="Window_Loaded" Closing="Window_Closing">

--- a/Ploco/MainWindow.xaml.cs
+++ b/Ploco/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -321,6 +321,15 @@ namespace Ploco
                 track.Locomotives.Remove(loco);
                 loco.AssignedTrackId = null;
                 loco.AssignedTrackOffsetX = null;
+
+                if (track.Name.Equals("ATE", StringComparison.OrdinalIgnoreCase) &&
+                    loco.Status == LocomotiveStatus.HS && loco.HsReason == "ATE")
+                {
+                    loco.Status = LocomotiveStatus.Ok;
+                    loco.HsReason = null;
+                    Logger.Debug($"Locomotive {loco.Number} automatically set to Ok because removed from ATE track to pool.", "Movement");
+                }
+
                 await _repository.AddHistoryAsync("LocomotiveRemoved", $"Loco {loco.Number} retirée de {track.Name}.");
             }
         }
@@ -415,37 +424,40 @@ namespace Ploco
             Logger.Debug($"Opened context menu on loco Id={loco.Id} Number={loco.Number} IsForecastOrigin={loco.IsForecastOrigin} IsForecastGhost={loco.IsForecastGhost}", "ContextMenu");
 
             // Find menu items by name - we need to search through the Items collection
-            MenuItem? placementItem = null;
-            MenuItem? annulerItem = null;
-            MenuItem? validerItem = null;
-
             foreach (var item in contextMenu.Items)
             {
-                if (item is MenuItem menuItem)
+                if (item is FrameworkElement fe)
                 {
-                    if (menuItem.Header?.ToString() == "Placement prévisionnel")
-                        placementItem = menuItem;
-                    else if (menuItem.Header?.ToString() == "Annuler le placement prévisionnel")
-                        annulerItem = menuItem;
-                    else if (menuItem.Header?.ToString() == "Valider le placement prévisionnel")
-                        validerItem = menuItem;
+                    if (loco.IsForecastGhost)
+                    {
+                        if (fe is MenuItem menuItem && (menuItem.Header?.ToString() == "Annuler le placement prévisionnel" || menuItem.Header?.ToString() == "Valider le placement prévisionnel"))
+                        {
+                            fe.Visibility = Visibility.Visible;
+                        }
+                        else
+                        {
+                            fe.Visibility = Visibility.Collapsed;
+                        }
+                    }
+                    else
+                    {
+                        if (fe is MenuItem menuItem)
+                        {
+                            var header = menuItem.Header?.ToString();
+                            // Normal visibility rules for origin or normal locos
+                            if (header == "Placement prévisionnel")
+                                menuItem.Visibility = loco.IsForecastOrigin ? Visibility.Collapsed : Visibility.Visible;
+                            else if (header == "Annuler le placement prévisionnel" || header == "Valider le placement prévisionnel")
+                                menuItem.Visibility = loco.IsForecastOrigin ? Visibility.Visible : Visibility.Collapsed;
+                            else
+                                menuItem.Visibility = Visibility.Visible;
+                        }
+                        else
+                        {
+                            fe.Visibility = Visibility.Visible; // Show separators for normal locos
+                        }
+                    }
                 }
-            }
-
-            // Show/hide based on forecast state
-            if (placementItem != null)
-            {
-                placementItem.Visibility = loco.IsForecastOrigin ? Visibility.Collapsed : Visibility.Visible;
-            }
-
-            if (annulerItem != null)
-            {
-                annulerItem.Visibility = loco.IsForecastOrigin ? Visibility.Visible : Visibility.Collapsed;
-            }
-
-            if (validerItem != null)
-            {
-                validerItem.Visibility = loco.IsForecastOrigin ? Visibility.Visible : Visibility.Collapsed;
             }
         }
 

--- a/Ploco/SplashWindow.xaml.cs
+++ b/Ploco/SplashWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace Ploco
         {
             InitializeComponent();
             
-            TxtVersion.Text = "Version 1.0.7 - Stable";
+            TxtVersion.Text = "Version 1.0.8 - Stable";
         }
 
         public void UpdateProgress(int percentage, string statusMessage)

--- a/Ploco/ViewModels/MainViewModel.Forecast.cs
+++ b/Ploco/ViewModels/MainViewModel.Forecast.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using CommunityToolkit.Mvvm.Input;
+using Ploco.Dialogs;
 using Ploco.Helpers;
 using Ploco.Models;
 
@@ -25,7 +26,7 @@ namespace Ploco.ViewModels
                 return;
             }
 
-            var targetTrack = _dialogService.ShowRollingLineSelectionDialog(Tiles);
+            var targetTrack = _dialogService.ShowTargetTrackSelectionDialog(Tiles);
             if (targetTrack == null) return;
 
             loco.IsForecastOrigin = true;
@@ -34,6 +35,8 @@ namespace Ploco.ViewModels
             var ghost = PrevisionnelLogicHelper.CreateGhostFrom(loco);
             ghost.AssignedTrackId = targetTrack.Id;
             targetTrack.Locomotives.Add(ghost);
+            
+            PlacementLogicHelper.EnsureTrackOffsets(targetTrack);
 
             await _repository.AddHistoryAsync("ForecastPlacement", $"Placement prévisionnel de la loco {loco.Number} vers {targetTrack.Name}.");
             OnStatePersisted?.Invoke();
@@ -43,14 +46,29 @@ namespace Ploco.ViewModels
         [RelayCommand]
         public async Task AnnulerPrevisionnelAsync(LocomotiveModel loco)
         {
-            if (loco == null || !loco.IsForecastOrigin) return;
+            if (loco == null) return;
+            
+            var originLoco = loco.IsForecastGhost 
+                ? Locomotives.FirstOrDefault(l => l.Id == loco.ForecastSourceLocomotiveId || l.Number == loco.Number) 
+                : loco;
+                
+            if (originLoco == null)
+            {
+                _dialogService.ShowError("Erreur", "Locomotive d'origine introuvable pour ce fantôme.");
+                return;
+            }
+            if (!originLoco.IsForecastOrigin)
+            {
+                _dialogService.ShowError("Erreur", "La locomotive cible n'est pas marquée comme origine d'un prévisionnel.");
+                return;
+            }
 
-            PrevisionnelLogicHelper.RemoveForecastGhostsFor(loco, Tiles);
+            PrevisionnelLogicHelper.RemoveForecastGhostsFor(originLoco, Tiles);
 
-            loco.IsForecastOrigin = false;
-            loco.ForecastTargetRollingLineTrackId = null;
+            originLoco.IsForecastOrigin = false;
+            originLoco.ForecastTargetRollingLineTrackId = null;
 
-            await _repository.AddHistoryAsync("ForecastCancelled", $"Annulation du placement prévisionnel de la loco {loco.Number}.");
+            await _repository.AddHistoryAsync("ForecastCancelled", $"Annulation du placement prévisionnel de la loco {originLoco.Number}.");
             OnStatePersisted?.Invoke();
             OnWorkspaceChanged?.Invoke();
         }
@@ -58,17 +76,32 @@ namespace Ploco.ViewModels
         [RelayCommand]
         public async Task ValiderPrevisionnelAsync(LocomotiveModel loco)
         {
-            if (loco == null || !loco.IsForecastOrigin) return;
+            if (loco == null) return;
+            
+            var originLoco = loco.IsForecastGhost 
+                ? Locomotives.FirstOrDefault(l => l.Id == loco.ForecastSourceLocomotiveId || l.Number == loco.Number) 
+                : loco;
+                
+            if (originLoco == null)
+            {
+                _dialogService.ShowError("Erreur", "Locomotive d'origine introuvable pour ce fantôme.");
+                return;
+            }
+            if (!originLoco.IsForecastOrigin)
+            {
+                _dialogService.ShowError("Erreur", "La locomotive cible n'est pas marquée comme origine d'un prévisionnel.");
+                return;
+            }
 
-            var targetTrackId = loco.ForecastTargetRollingLineTrackId;
+            var targetTrackId = originLoco.ForecastTargetRollingLineTrackId;
             if (targetTrackId == null)
             {
-                _dialogService.ShowError("Erreur", "Ligne de roulement cible non définie.");
+                _dialogService.ShowError("Erreur", "Ligne cible non définie.");
                 return;
             }
 
             var targetTrack = Tiles.SelectMany(t => t.Tracks)
-                .FirstOrDefault(t => t.Locomotives.Any(l => PrevisionnelLogicHelper.IsGhostOf(loco, l)));
+                .FirstOrDefault(t => t.Locomotives.Any(l => PrevisionnelLogicHelper.IsGhostOf(originLoco, l)));
 
             if (targetTrack == null)
             {
@@ -76,19 +109,23 @@ namespace Ploco.ViewModels
                 return;
             }
 
-            PrevisionnelLogicHelper.RemoveForecastGhostsFor(loco, Tiles);
+            PrevisionnelLogicHelper.RemoveForecastGhostsFor(originLoco, Tiles);
 
             var realLocosInTarget = targetTrack.Locomotives.Where(l => !l.IsForecastGhost).ToList();
-            if (realLocosInTarget.Any())
+            if (realLocosInTarget.Any() && targetTrack.Kind == TrackKind.RollingLine)
             {
-                var prompt = $"La ligne {targetTrack.Name} est occupée par la locomotive {realLocosInTarget.First().Number}.\nVoulez-vous quand même valider le placement prévisionnel ? Cela remplacera la locomotive existante.";
-                if (!_dialogService.ShowConfirmation("Ligne occupée", prompt))
+                var existingLoco = realLocosInTarget.First();
+                var action = _dialogService.ShowReplaceLocomotiveDialog(targetTrack.Name, existingLoco.Number.ToString());
+                
+                if (action == ReplaceAction.Cancel)
                 {
-                    var ghost = PrevisionnelLogicHelper.CreateGhostFrom(loco);
+                    var ghost = PrevisionnelLogicHelper.CreateGhostFrom(originLoco);
                     ghost.AssignedTrackId = targetTrack.Id;
                     targetTrack.Locomotives.Add(ghost);
                     return;
                 }
+
+                var originTrack = Tiles.SelectMany(t => t.Tracks).FirstOrDefault(t => t.Id == originLoco.AssignedTrackId);
 
                 foreach (var realLoco in realLocosInTarget.ToList())
                 {
@@ -96,15 +133,24 @@ namespace Ploco.ViewModels
                     realLoco.AssignedTrackId = null;
                     realLoco.AssignedTrackOffsetX = null;
                 }
+
+                if (action == ReplaceAction.Swap && originTrack != null)
+                {
+                    // Déplacer l'ancienne locomotive vers la voie d'origine de la nouvelle
+                    MoveLocomotiveToTrack(existingLoco, originTrack, 0);
+                }
             }
 
-            loco.IsForecastOrigin = false;
-            loco.ForecastTargetRollingLineTrackId = null;
+            originLoco.IsForecastOrigin = false;
+            originLoco.ForecastTargetRollingLineTrackId = null;
 
             // Déplace la locomotive (MoveLocomotiveToTrack est déjà défini dans MainViewModel.Tiles.cs)
-            MoveLocomotiveToTrack(loco, targetTrack, 0);
+            MoveLocomotiveToTrack(originLoco, targetTrack, 0);
 
-            await _repository.AddHistoryAsync("ForecastValidated", $"Validation du placement prévisionnel de {loco.Number} sur {targetTrack.Name}.");
+            // S'assure que les offsets sont recalculés correctement au cas où
+            PlacementLogicHelper.EnsureTrackOffsets(targetTrack);
+
+            await _repository.AddHistoryAsync("ForecastValidated", $"Validation du placement prévisionnel de {originLoco.Number} sur {targetTrack.Name}.");
             OnStatePersisted?.Invoke();
             OnWorkspaceChanged?.Invoke();
         }

--- a/Ploco/ViewModels/MainViewModel.Tiles.cs
+++ b/Ploco/ViewModels/MainViewModel.Tiles.cs
@@ -126,6 +126,13 @@ namespace Ploco.ViewModels
                         track.Locomotives.Remove(loco);
                         loco.AssignedTrackId = null;
                         loco.AssignedTrackOffsetX = null;
+
+                        if (track.Name.Equals("ATE", StringComparison.OrdinalIgnoreCase) &&
+                            loco.Status == LocomotiveStatus.HS && loco.HsReason == "ATE")
+                        {
+                            loco.Status = LocomotiveStatus.Ok;
+                            loco.HsReason = null;
+                        }
                     }
                 }
                 
@@ -245,6 +252,13 @@ namespace Ploco.ViewModels
 
                 track.Locomotives.Remove(loco);
                 loco.AssignedTrackId = null;
+
+                if (track.Name.Equals("ATE", StringComparison.OrdinalIgnoreCase) &&
+                    loco.Status == LocomotiveStatus.HS && loco.HsReason == "ATE")
+                {
+                    loco.Status = LocomotiveStatus.Ok;
+                    loco.HsReason = null;
+                }
             }
             tile.Tracks.Remove(track);
             tile.RefreshTrackCollections();
@@ -413,6 +427,15 @@ namespace Ploco.ViewModels
                 currentTrack.Locomotives.Remove(loco);
                 Helpers.Logger.Debug($"Locomotive removed from source track {currentTrack.Name}", "Movement");
                 
+                if (currentTrack.Name.Equals("ATE", StringComparison.OrdinalIgnoreCase) && 
+                    !targetTrack.Name.Equals("ATE", StringComparison.OrdinalIgnoreCase) &&
+                    loco.Status == LocomotiveStatus.HS && loco.HsReason == "ATE")
+                {
+                    loco.Status = LocomotiveStatus.Ok;
+                    loco.HsReason = null;
+                    Helpers.Logger.Debug($"Locomotive {loco.Number} automatically set to Ok because removed from ATE track.", "Movement");
+                }
+                
                 if (!currentTrack.Locomotives.Any() && currentTrack.Kind == TrackKind.Line)
                 {
                     var parentTile = Tiles.FirstOrDefault(t => t.Tracks.Contains(currentTrack));
@@ -427,7 +450,14 @@ namespace Ploco.ViewModels
                 }
             }
 
-            if (insertIndex >= 0 && insertIndex <= targetTrack.Locomotives.Count)
+            if ((targetTrack.Kind == TrackKind.Zone || targetTrack.Kind == TrackKind.Output))
+            {
+                // Workaround for WPF ListBox Canvas rendering issues when inserting at index 0.
+                // Since Zone/Output use Canvas, absolute positioning (Canvas.Left) dictates the layout, 
+                // so we can safely append to the ObservableCollection.
+                targetTrack.Locomotives.Add(loco);
+            }
+            else if (insertIndex >= 0 && insertIndex <= targetTrack.Locomotives.Count)
             {
                 targetTrack.Locomotives.Insert(insertIndex, loco);
             }
@@ -437,6 +467,14 @@ namespace Ploco.ViewModels
             }
             
             loco.AssignedTrackId = targetTrack.Id;
+
+            if (targetTrack.Name.Equals("ATE", StringComparison.OrdinalIgnoreCase))
+            {
+                loco.Status = LocomotiveStatus.HS;
+                loco.HsReason = "ATE";
+                Helpers.Logger.Debug($"Locomotive {loco.Number} automatically set to HS ATE because placed on ATE track.", "Movement");
+            }
+
             Helpers.Logger.Debug($"Locomotive added to target track {targetTrack.Name} at position {targetTrack.Locomotives.IndexOf(loco)}", "Movement");
             UpdatePoolVisibility();
             OnStatePersisted?.Invoke();
@@ -534,6 +572,10 @@ namespace Ploco.ViewModels
                 if (!tile.Tracks.Any(t => t.Kind == TrackKind.Zone && t.Name == "917"))
                 {
                     tile.Tracks.Add(new TrackModel { Name = "917", Kind = TrackKind.Zone, LeftLabel = "BLOCK", RightLabel = "BIF" });
+                }
+                if (!tile.Tracks.Any(t => t.Kind == TrackKind.Zone && t.Name.Equals("ATE", StringComparison.OrdinalIgnoreCase)))
+                {
+                    tile.Tracks.Add(new TrackModel { Name = "ATE", Kind = TrackKind.Zone });
                 }
             }
             else if (tile.Name.Equals("Zeebrugge", StringComparison.OrdinalIgnoreCase))

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,461 +1,75 @@
 # Ploco - Notes de Version
 
-## Version 1.0.5 - Février 2026
+## Version 2.0.0 - Février 2026 : La Renaissance Architecturale
 
-**Date de release** : 9 février 2026
+**Date de release** : 25 février 2026
 
-Cette version majeure apporte des fonctionnalités de planification avancées, une gestion améliorée des statuts, et de nombreuses améliorations d'ergonomie.
-
----
-
-## 🎯 Nouvelles Fonctionnalités Majeures
-
-### 🔵 Placement Prévisionnel (Forecast Placement)
-
-**Planifiez vos affectations de locomotives avant de les déplacer réellement !**
-
-Cette nouvelle fonctionnalité révolutionnaire permet de visualiser et planifier les futurs emplacements des locomotives sans les déplacer physiquement.
-
-#### Comment ça marche ?
-
-1. **Activer le mode prévisionnel**
-   - Clic droit sur une locomotive assignée à une tuile
-   - Sélectionner "Placement prévisionnel"
-   - Choisir une ligne de roulement dans la liste
-
-2. **Indicateurs visuels**
-   - 🔵 **Locomotive bleue** dans sa tuile d'origine : en attente de validation
-   - 🟢 **Copie fantôme verte** sur la ligne cible : position future planifiée
-
-3. **Validation ou Annulation**
-   - **Valider** : La locomotive est effectivement déplacée sur la ligne cible
-   - **Annuler** : Tout est réinitialisé, la locomotive retrouve sa couleur normale
-
-#### Avantages
-- ✅ Planification logistique facilitée
-- ✅ Visualisation claire des futures affectations
-- ✅ Aucun risque de déplacement accidentel
-- ✅ Gestion intelligente des conflits (ligne occupée entre-temps)
-
-#### Sécurité
-- Les copies fantômes ne peuvent pas être déplacées (drag & drop bloqué)
-- Les fantômes ne sont jamais sauvegardés en base de données
-- Protection contre les opérations non autorisées
-
-#### Cas d'usage
-- **Planification de roulement** : Préparer les affectations pour le lendemain
-- **Organisation multi-locomotives** : Visualiser plusieurs placements avant validation
-- **Coordination d'équipe** : Voir les futures positions avant déplacement physique
+Cette version **2.0.0** est probablement la mise à jour la plus importante de l'histoire de Ploco. Elle marque l'aboutissement d'une refonte architecturale totale (Refactoring en 4 phases) et l'introduction de fonctionnalités d'interface utilisateur très demandées. Ploco est désormais plus rapide, plus stable et plus ergonomique que jamais.
 
 ---
 
-### 📦 Import de Données par Lot
+## 🛠️ Refonte Architecturale Majeure (Sous le capot)
 
-**Synchronisez vos pools de locomotives en un seul clic depuis Excel ou n'importe quelle source texte !**
+L'application a été entièrement réécrite pour abandonner son "Code-Behind" monolithique au profit des standards de développement modernes de Microsoft.
 
-#### Accès
-Menu **Options > Import**
+1. **Migration vers MVVM Stricte (Phase 1 à 3)**
+   - L'interface ne gère plus la logique. Tout le cerveau de l'application est dorénavant encapsulé dans le `MainViewModel`.
+   - L'introduction d'un conteneur d'**Injection de Dépendances (IoC)** garantit que chaque service (Base de données, Dialogues) est appelé de façon sécurisée et isolée.
+   - Les actions complexes (telles que le fameux Drag & Drop intelligent des locomotives et la gestion des "Fantômes") ont été portées vers des *Attached Behaviors* et des *RelayCommands* pures.
 
-#### Fonctionnement
+2. **Asynchronisme de bout en bout (Phase 4)**
+   - **Adieu les freezes !** L'intégralité du dialogue avec la base de données SQLite (`IPlocoRepository`) a été basculée en asynchrone (`async/await`). 
+   - Qu'il s'agisse de charger l'historique massif, d'importer un Excel de 500 lignes, ou de sauvegarder le Tapis T13, l'interface utilisateur restera fluide et réactive à 100%.
 
-La fenêtre pré-remplit automatiquement le contenu de votre presse-papier :
-
-```
-1310
-1311
-1312
-1313
-1314
-```
-
-#### Synchronisation Bidirectionnelle Automatique
-
-L'import effectue une **synchronisation complète** :
-
-1. **Ajout à Sibelit**
-   - Locomotives listées + existantes dans la base + pas encore dans Sibelit
-   - → **Ajoutées automatiquement à Sibelit**
-
-2. **Retour à Lineas**
-   - Locomotives dans Sibelit mais **non listées** dans l'import
-   - → **Retournées automatiquement à Lineas**
-
-3. **Inchangées**
-   - Locomotives déjà dans Sibelit et listées dans l'import
-   - → **Restent dans Sibelit**
-
-#### Résultats Détaillés
-
-Après chaque import :
-```
-Import terminé !
-
-- 15 locomotive(s) ajoutée(s) à Sibelit
-- 3 locomotive(s) retournée(s) à Lineas
-- 5 locomotive(s) déjà dans Sibelit (inchangées)
-```
-
-#### Avantages
-- ✅ **Rapidité** : Copier/coller au lieu de sélection manuelle
-- ✅ **Fiabilité** : Aucun oubli possible, synchronisation totale
-- ✅ **Simplicité** : Format texte simple, compatible Excel/CSV
-- ✅ **Feedback** : Statistiques claires et détaillées
-- ✅ **Traçabilité** : Tous les imports sont loggés
-
-#### Validation
-- Ignore les lignes vides et non-numériques
-- N'importe que les locomotives existantes dans la base
-- Affiche un avertissement si aucun numéro valide détecté
+3. **Environnement de Tests Unitaires (Phase 4)**
+   - Réécriture de la logique mathématique et métier sous forme de `Helpers` purs, désormais blindés par une suite de **Tests Unitaires Automatisés (xUnit & Moq)**.
+   - La prévention des bugs régressifs est désormais garantie mathématiquement avant chaque livraison.
 
 ---
 
-### 🟡 Nouveau Statut "Défaut Mineur"
+## 🎨 Nouvelles Fonctionnalités d'Interface (UI)
 
-**Un statut intermédiaire pour les problèmes mineurs nécessitant vérification !**
+Outre la stabilité monumentale apportée par le refactoring, de nouveaux superbes ajouts ergonomiques complètent cette V2 :
 
-#### Présentation
+### 1. Tiroir Latéral Rétractable (Drawer)
+La gestion de l'espace a été repensée. Le menu latéral gauche (contenant les locomotives non assignées) est désormais **rétractable**.
+- Un simple clic permet de masquer ou d'afficher le tiroir.
+- Maximise l'espace dédié au Canvas (vos dépôts et lignes) sur les plus petits écrans.
+- Animation fluide de l'ouverture et fermeture (si activée).
 
-Nouveau statut entre "OK" et "HS" permettant une gestion plus fine des problèmes de locomotives.
+### 2. Splash Screen de Chargement
+Lors de la première ouverture ou de chargements massifs de bases de données (imports lourds), Ploco affiche dorénavant un élégant **Écran de chargement (Splash Screen)** au lieu de figer l'écran ou de présenter une interface vide. Vous savez toujours ce que Ploco est en train de faire.
 
-#### Caractéristiques
-
-- **Couleur** : 🟡 Jaune (distincte de tous les autres statuts)
-- **Champ obligatoire** : Description du problème requise
-- **Validation stricte** : Impossible de valider sans remplir la description
-- **Nettoyage automatique** : La description est effacée si vous changez vers un autre statut
-
-#### Utilisation
-
-1. Clic droit sur une locomotive
-2. "Modifier le statut" → "A verifier / Defaut mineur"
-3. **Remplir obligatoirement** la description du problème
-   - Exemple : "Problème de freinage mineur", "Fuite d'huile légère"
-4. Valider
-
-#### Persistance
-- Description sauvegardée dans SQLite (colonne `defaut_info`)
-- Rechargée automatiquement au démarrage
-- Historique complet dans les logs
-
-#### Les 4 Statuts
-- ✅ **OK** (Vert) : Locomotive opérationnelle
-- 🟠 **Manque de Traction** (Orange) : Traction réduite
-- 🟡 **Défaut Mineur** (Jaune) : À vérifier ← **NOUVEAU**
-- 🔴 **HS** (Rouge) : Hors service
-
-#### Avantages
-- ✅ Gestion fine des maintenances
-- ✅ Traçabilité des problèmes mineurs
-- ✅ Ne pas marquer HS pour des petits problèmes
-- ✅ Documentation obligatoire des défauts
+### 3. Refonte Visuelle du Placement Prévisionnel
+Les couleurs du système de "Fantômes" (Forecast) ont été retravaillées pour une meilleure lisibilité visuelle selon les retours métier :
+- **Locomotive Originale en attente** : Affichée en **Bleu**.
+- **Fantôme cible (Copie)** : Affiché en **Bleu Clair**.
+- Ce code couleur remplace l'ancien Vert, permettant de mieux contraster avec le Statut "OK" (Vert).
 
 ---
 
-### 📊 TapisT13 - Implémentation Complète
+## ⚡ Rappel des Fonctionnalités Clés Récentes (V1.0.5 incluses dans la V2)
 
-**Rapport T13 intelligent avec support du placement prévisionnel !**
+### Gestion Intelligente des Pools
+- Double-clic immédiat pour transférer une loco de *Sibelit* vers *Lineas*.
+- Outil d'Import intelligent Excel ↔ Base de données pour synchroniser un parc complet en un clic.
 
-#### Améliorations Majeures
+### Système de Statuts Avancé
+- Les 4 statuts historiques : ✅ **OK**, 🟡 **Défaut Mineur** (avec commentaire obligatoire), 🟠 **Manque Traction** (avec %), et 🔴 **HS**.
+- Cohérence parfaite sur la grille, la liste et le rendu final PDF du rapport Tapis T13.
 
-##### 1. Support du Placement Prévisionnel
-Le rapport T13 prend en compte le **mode prévisionnel** :
-- Si locomotive en mode prévisionnel (bleue) → utilise la position du **ghost** (position future)
-- Sinon → utilise la position réelle actuelle
+### Mémorisation de l'Espace de Travail
+- La taille, la position de vos fenêtres, et vos préférences de mode sombre sont toujours sauvegardées.
 
-##### 2. Affichage Différencié par Contexte
-
-**Locomotives HS (Hors Service)**
-- 🔴 Affichage rouge : **"TileName TrainNumber"**
-- Apparaît dans les **deux colonnes** (report + gestion)
-
-**Locomotives OK/ManqueTraction sur Ligne avec Train**
-- 🟢 Affichage vert : **"TileName TrainNumber"**
-- Apparaît uniquement dans la **colonne rapport**
-
-**Locomotives disponibles (Dépôt/Garage)**
-- Pas de couleur : **"DISPO TileName"**
-
-**Locomotives sur ligne de roulement**
-- Pas de couleur : **"1103"** (numéro seul)
-
-##### 3. Pourcentages de Traction
-Le rapport inclut maintenant les **pourcentages de traction** :
-- 75%, 50%, 25% affichés à côté du statut
-- Permet une vision précise de la capacité de traction
-
-#### Logique Technique
-- Utilise uniquement les propriétés existantes du modèle
-- Aucune nouvelle règle métier inventée
-- Cohérence totale avec le système existant
+### Logging unifié
+- Système propulsé par `Serilog` garantissant que le moindre comportement (déplacement, mise à jour, erreur SQLite) est audité et conservé pendant 30 jours dans votre répertoire système `%AppData%`.
 
 ---
 
-## 🎯 Améliorations d'Ergonomie
-
-### ⚡ Double-Clic Transfert de Pool
-
-**Transférez instantanément une locomotive entre pools !**
-
-- **Double-cliquez** sur une locomotive dans la liste
-- Elle passe automatiquement de Sibelit → Lineas (ou inverse)
-- Plus besoin d'ouvrir la fenêtre de gestion des pools
-- Hit-testing précis (ne dépend pas de la sélection)
-
-**Gain de temps énorme** pour les opérations fréquentes !
+## 🐛 Corrections de Bugs et Optimisations
+- Élimination de plus de 15 *Warnings* de nullité structurale au moment de la compilation (`CS8600`, `CS8618`).
+- Correction complexe de l'affichage du Tapis T13 où la vue et la mémoire luttaient parfois à contresens (résolu via MVC asynchrone).
 
 ---
 
-### 💾 Sauvegarde Automatique des Fenêtres
-
-**Vos fenêtres se souviennent de leur taille et position !**
-
-#### Fonctionnalité
-- **Taille** : Largeur et hauteur sauvegardées
-- **Position** : X et Y sur l'écran
-- **État** : Normal ou Maximisé
-
-#### Fenêtres Concernées
-- MainWindow (fenêtre principale)
-- TapisT13Window
-- PoolTransferWindow
-- DatabaseWindow
-- ImportWindow
-
-#### Stockage
-Fichier `%AppData%\Ploco\WindowSettings.json`
-
-#### Avantages
-- ✅ Plus besoin de redimensionner à chaque ouverture
-- ✅ Chaque fenêtre retrouve automatiquement son état
-- ✅ Multi-écrans supporté
-
----
-
-### 📝 Informations de Traction Enrichies
-
-**Documentez précisément les problèmes de traction !**
-
-#### Nouvelles Capacités
-
-1. **Commentaire optionnel** pour le statut "Manque de Traction"
-   - Permet de décrire le problème précisément
-   - Exemple : "Moteur 2 défaillant", "Puissance réduite temporairement"
-
-2. **Pourcentage de traction** affiché dans les rapports
-   - 75% : Léger manque de traction
-   - 50% : Traction moyennement réduite
-   - 25% : Traction fortement réduite
-
-3. **Intégration dans T13**
-   - Les pourcentages apparaissent dans le rapport T13
-   - Vision claire de l'état du parc
-
-#### Avantages
-- ✅ Documentation précise des problèmes
-- ✅ Meilleure traçabilité
-- ✅ Aide à la décision (affectation selon capacité)
-
----
-
-### 📋 Système de Logs Complet
-
-**Traçabilité totale de toutes les opérations !**
-
-#### Fonctionnalités
-
-1. **Enregistrement automatique**
-   - Démarrage/arrêt de l'application
-   - Déplacements de locomotives
-   - Changements de statut
-   - Opérations de forecast (placement prévisionnel)
-   - Imports de données
-   - Erreurs et exceptions
-
-2. **Stockage organisé**
-   - Dossier : `%AppData%\Ploco\Logs\`
-   - Format : `ploco-YYYYMMDD.log`
-   - Rotation automatique sur **30 jours**
-
-3. **Accès rapide**
-   - Menu **Options > Ouvrir les logs**
-   - Ouvre directement le dossier des logs
-
-4. **Format structuré**
-```
-[2026-02-09 14:23:45] [INFO] [Startup] Application démarrée
-[2026-02-09 14:24:12] [INFO] [Movement] Locomotive 1310 déplacée vers Ligne 1105
-[2026-02-09 14:25:33] [INFO] [Status] Status changed for loco 1312: Ok -> DefautMineur
-[2026-02-09 14:26:01] [INFO] [Import] Import locomotives: 15 ajoutées, 3 retirées, 5 inchangées
-```
-
-#### Avantages
-- ✅ Diagnostic facilité en cas de problème
-- ✅ Audit complet des opérations
-- ✅ Historique détaillé
-- ✅ Thread-safe (multi-threading supporté)
-
----
-
-## 🐛 Corrections de Bugs
-
-### Rafraîchissement de la Liste Gauche après Import
-**Problème** : Après import de locomotives, la liste de gauche ne se mettait pas à jour automatiquement. Il fallait ouvrir/fermer la fenêtre "Gestion de parc" pour voir les changements.
-
-**Solution** : Ajout d'un appel à `UpdatePoolVisibility()` dans `RefreshLocomotivesDisplay()` pour mettre à jour la propriété `IsVisibleInActivePool`.
-
-**Résultat** : La liste de gauche se rafraîchit maintenant immédiatement après un import. ✅
-
-### Gestion Robuste des Locomotives Fantômes
-**Amélioration** : Les locomotives fantômes (copies vertes du placement prévisionnel) ne sont jamais sauvegardées en base de données.
-
-**Protection** :
-- Filtrage lors de `PersistState()`
-- Blocage du drag & drop
-- Validation stricte avant opérations
-
-### Validation Stricte des Statuts
-**Amélioration** : Les statuts avec champs obligatoires (DefautMineur, HS) sont maintenant strictement validés.
-
-**Bénéfice** : Impossible de sauvegarder un statut sans remplir les informations requises.
-
----
-
-## 📊 Statistiques de cette Version
-
-- ✅ **4 fonctionnalités majeures** ajoutées
-- ✅ **5 améliorations d'ergonomie** significatives
-- ✅ **3 corrections de bugs** critiques
-- ✅ **0 warnings, 0 errors** au build
-- ✅ **100% compatible** avec les versions précédentes
-- ✅ Documentation complète en français
-
----
-
-## 🔧 Stack Technique
-
-### Technologies
-- .NET 8.0
-- WPF (Windows Presentation Foundation)
-- SQLite (Microsoft.Data.Sqlite)
-- Newtonsoft.Json
-
-### Architecture
-- MVVM Pattern avec INotifyPropertyChanged
-- WPF DataTriggers pour les couleurs de forecast
-- Système de persistance robuste (SQLite + JSON)
-- Logging thread-safe avec rotation
-
----
-
-## 📦 Migration depuis Version Précédente
-
-### Base de Données
-La migration est **automatique** :
-- Nouvelle colonne `defaut_info` ajoutée via `EnsureColumn()`
-- Anciennes données préservées
-- Aucune action manuelle requise
-
-### Fichiers de Configuration
-Nouveaux fichiers créés automatiquement :
-- `%AppData%\Ploco\WindowSettings.json` (paramètres fenêtres)
-- `%AppData%\Ploco\Logs\` (dossier de logs)
-
-### Compatibilité
-✅ Toutes les données existantes sont préservées et compatibles
-
----
-
-## 📚 Documentation
-
-### Fichiers de Documentation Disponibles
-- `PLACEMENT_PREVISIONNEL.md` - Guide complet du placement prévisionnel
-- `IMPORT_WINDOW_DOCUMENTATION.md` - Guide d'utilisation de l'import
-- `DEFAUT_MINEUR_STATUS.md` - Documentation du statut DefautMineur
-- `TAPIS_T13_COMPLETE_IMPLEMENTATION.md` - Détails techniques TapisT13
-- `SAUVEGARDE_TAILLE_FENETRES.md` - Système de sauvegarde fenêtres
-- `LOGGING_SYSTEM.md` - Documentation du système de logs
-- `TRACTION_INFO_FEATURE.md` - Informations de traction enrichies
-
----
-
-## 🎯 Utilisation Rapide des Nouvelles Fonctionnalités
-
-### Placement Prévisionnel
-```
-1. Clic droit sur locomotive → "Placement prévisionnel"
-2. Choisir ligne de roulement
-3. Locomotive devient bleue, copie verte apparaît
-4. Valider ou Annuler
-```
-
-### Import de Locomotives
-```
-1. Copier numéros depuis Excel
-2. Menu Options > Import
-3. Cliquer "Importer Locomotives"
-4. Voir les statistiques de synchronisation
-```
-
-### Statut Défaut Mineur
-```
-1. Clic droit → Modifier le statut
-2. Sélectionner "A verifier / Defaut mineur"
-3. Remplir description obligatoire
-4. Valider → Locomotive devient jaune
-```
-
-### Double-Clic Transfert
-```
-1. Double-cliquer sur une locomotive
-2. Elle change instantanément de pool (Sibelit ↔ Lineas)
-```
-
-### Accès aux Logs
-```
-Menu Options > Ouvrir les logs
-→ Dossier %AppData%\Ploco\Logs\ s'ouvre
-```
-
----
-
-## 🚀 Prochaines Évolutions Prévues
-
-### Court Terme
-- Import des dates d'entretien depuis presse-papier
-- Export Excel/CSV des données
-- Notifications pour locomotives HS
-
-### Moyen Terme
-- Module de statistiques avancées
-- Synchronisation cloud optionnelle
-- Application mobile companion
-
-### Long Terme
-- Support multi-utilisateurs
-- Système de permissions
-- API REST pour intégrations tierces
-
----
-
-## 💬 Support
-
-Pour toute question ou problème :
-1. Consultez les fichiers de documentation (*.md)
-2. Vérifiez les logs dans `%AppData%\Ploco\Logs\`
-3. Contactez le développeur
-
----
-
-## 👨‍💻 Développeur
-
-**LinkAtPlug**
-
----
-
-## 📄 Licence
-
-Ce projet est distribué sous licence MIT.
-
----
-
-**Version 2.0.0 - Une mise à jour majeure pour une gestion de parc encore plus efficace ! 🚂✨**
+**Version 2.0.0 - Une fondation indestructible pour le futur de Ploco ! 🚂✨**


### PR DESCRIPTION
Bugs corrigés :
- Menu Contextuel : Les locomotives fantômes n'affichent plus toutes les actions par défaut (Modifier statut, swap, retirer...). Seules les options "Valider" et "Annuler le placement" sont désormais disponibles au clic droit.
- Disparition sur les Zones : Résolution d'un bug majeur de rendu WPF (Canvas) où la validation d'une locomotive prévisionnelle sur une "Zone" (comme ATE ou 917) la rendait invisible à l'écran. Modification de la méthode d'insertion (.Insert remplacé par .Add) pour rétablir l'affichage correct et recalcul automatique des offsets. Nouvelles fonctionnalités :
- Automatisation Statut ATE : Lorsqu'une locomotive quitte la voie ATE (glissée vers une autre voie, le tiroir, ou tuile vidée), son statut "HS - ATE" repasse automatiquement en "Ok" (Vert). Les statuts appliqués manuellement sont conservés pour éviter les écrasements involontaires.